### PR TITLE
Add 7 Alaska ports to seasonal-guides.json

### DIFF
--- a/REASONING-LOG.md
+++ b/REASONING-LOG.md
@@ -28,6 +28,18 @@ compliance from anyone — if the run happened, the entry is true.
 
 ---
 
+## 2026-09-03 — Seven Alaska ports into seasonal-guides.json (grok1)
+
+**Asked.** Keep looping. HLS `itw-alaska-seasonal-json` (#2446): college-fjord, homer, kodiak, misty-fjords, petersburg, valdez, wrangell missing from seasonal-guides.json.
+
+**Weighed.** Inventing humidity/rain_days would fail original-research. NOAA 1991-2020 highs/lows (and rain_days where the Wikipedia climate table had them) were used. Humidity and some rain_days borrowed from nearest existing registry stations (Seward, Sitka, Whittier, Ketchikan) and named in `_source`. Misty Fjords and College Fjord have no town stations.
+
+**Decided.** Seven tier-1 entries. `_meta.lastUpdated` 2026-09-03. 381→387 port keys.
+
+**Unsure.** Wrangell monthly precip-days were not in the Wikipedia table; Ketchikan rain_days used and disclosed.
+
+---
+
 ## 2026-08-28 — Reader-support CTA on every article and voyage pack (syl)
 
 **Asked.** Ken: put https://buymeacoffee.com/inthewake with a CTA in every article and
@@ -67,6 +79,18 @@ but that is a harness change and needs its own review, not a same-breath edit. A
 articles/cruise-tech-photography-guide.html was missing both analytics blocks (absent in
 the committed version too, verified via git show) and was the only article failing the
 validator; it now carries the same block as its 51 siblings and passes.
+
+---
+
+## 2026-09-03 — Seven Alaska ports into seasonal-guides.json (grok1)
+
+**Asked.** Keep looping. After FAQ_COUNT, HLS checkout `itw-alaska-seasonal-json` (#2446): college-fjord, homer, kodiak, misty-fjords, petersburg, valdez, wrangell missing.
+
+**Weighed.** Inventing humidity/rain_days would fail original-research. NOAA 1991-2020 highs/lows (and rain_days where the Wikipedia climate table had them) were used. Humidity and some rain_days borrowed from nearest existing registry stations (Seward, Sitka, Whittier, Ketchikan) and named in `_source`. Misty Fjords and College Fjord have no town stations.
+
+**Decided.** Seven tier-1 entries, `_meta.lastUpdated` 2026-09-03. 381→387 port keys.
+
+**Unsure.** Wrangell monthly precip-days were not in the Wikipedia table; Ketchikan rain_days used and disclosed.
 
 ---
 

--- a/assets/data/ports/seasonal-guides.json
+++ b/assets/data/ports/seasonal-guides.json
@@ -2,7 +2,7 @@
   "_meta": {
     "version": "1.0.0",
     "description": "Seasonal climate data for cruise ports. Tier 1 = hand-curated monthly climate data with activity recommendations, hazards, and packing tips.",
-    "lastUpdated": "2026-02-01"
+    "lastUpdated": "2026-09-03"
   },
   "abu-dhabi": {
     "tier": 1,
@@ -82,7 +82,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "56-106°F extreme desert range",
+      "temp_range": "56-106\u00b0F extreme desert range",
       "humidity": "Low inland; higher coastal",
       "rain": "Virtually none",
       "wind": "Occasional sandstorms; sea breeze helps coast",
@@ -127,11 +127,11 @@
       "Aug"
     ],
     "catches_off_guard": [
-      "Summer temperatures literally exceed 110°F in the shade",
-      "The Grand Mosque requires conservative dress — free abayas available",
+      "Summer temperatures literally exceed 110\u00b0F in the shade",
+      "The Grand Mosque requires conservative dress \u2014 free abayas available",
       "Yas Island and Ferrari World are air-conditioned alternatives",
       "Sandstorms can reduce visibility to near zero",
-      "Friday is the holy day — many businesses have different hours"
+      "Friday is the holy day \u2014 many businesses have different hours"
     ],
     "packing_nudges": [
       "Very light breathable clothing",
@@ -242,7 +242,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "72-90°F year-round tropical",
+      "temp_range": "72-90\u00b0F year-round tropical",
       "humidity": "Low dry season; high wet season",
       "rain": "Dry Nov-May; monsoon Jun-Oct",
       "wind": "Light; sea breezes",
@@ -283,10 +283,10 @@
       "Sep"
     ],
     "catches_off_guard": [
-      "La Quebrada cliff divers perform daily — iconic Acapulco tradition",
+      "La Quebrada cliff divers perform daily \u2014 iconic Acapulco tradition",
       "The bay views are spectacular from any of the hillside viewpoints",
       "Acapulco's golden age was the 1950s-70s but it's reviving",
-      "The old town and Zócalo have authentic Mexican character",
+      "The old town and Z\u00f3calo have authentic Mexican character",
       "Pie de la Cuesta has spectacular Pacific sunsets"
     ],
     "packing_nudges": [
@@ -298,7 +298,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "May 15 – Nov 30 (East Pacific)",
+      "hurricane_season": "May 15 \u2013 Nov 30 (East Pacific)",
       "peak_risk_months": [
         "Aug",
         "Sep",
@@ -404,8 +404,8 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "42-85°F Mediterranean climate (Southern Hemisphere)",
-      "humidity": "Low — Australia's driest state capital",
+      "temp_range": "42-85\u00b0F Mediterranean climate (Southern Hemisphere)",
+      "humidity": "Low \u2014 Australia's driest state capital",
       "rain": "Wetter winter; very dry summer",
       "wind": "Hot northerly winds in summer",
       "daylight": "10-14.5 hours (Southern Hemisphere)"
@@ -443,7 +443,7 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "Summer heat waves can push temperatures over 110°F",
+      "Summer heat waves can push temperatures over 110\u00b0F",
       "The Barossa Valley and McLaren Vale wine regions are world-class",
       "Adelaide Central Market is an excellent food destination",
       "Kangaroo Island is a 45-min ferry but whale-watching is seasonal",
@@ -558,7 +558,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "46-84°F — mild desert coast",
+      "temp_range": "46-84\u00b0F \u2014 mild desert coast",
       "humidity": "Moderate; oceanic influence",
       "rain": "Almost none May-Sep; light winter rain",
       "wind": "Moderate Atlantic breezes",
@@ -593,10 +593,10 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "Agadir was rebuilt after a devastating 1960 earthquake — modern city",
-      "The souk is one of Morocco's largest — great for shopping",
+      "Agadir was rebuilt after a devastating 1960 earthquake \u2014 modern city",
+      "The souk is one of Morocco's largest \u2014 great for shopping",
       "Paradise Valley (day trip) has natural swimming pools",
-      "Beach is the main draw — long, wide, and sunny",
+      "Beach is the main draw \u2014 long, wide, and sunny",
       "Less traditional than Marrakech or Fez but more relaxed"
     ],
     "packing_nudges": [
@@ -708,7 +708,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "57-87°F tropical",
+      "temp_range": "57-87\u00b0F tropical",
       "humidity": "Higher summer; moderate dry season",
       "rain": "Wetter Dec-Mar; dry Jun-Oct",
       "wind": "Trade winds; occasional cyclone threat",
@@ -752,9 +752,9 @@
     ],
     "catches_off_guard": [
       "Whitehaven Beach is spectacular but requires a boat",
-      "Box jellyfish (stingers) present Nov-May — suits required",
+      "Box jellyfish (stingers) present Nov-May \u2014 suits required",
       "Cyclone season (Dec-Apr) can disrupt itineraries",
-      "The Great Barrier Reef is right offshore — world-class snorkeling",
+      "The Great Barrier Reef is right offshore \u2014 world-class snorkeling",
       "Dry season has the best visibility and calmest seas"
     ],
     "packing_nudges": [
@@ -766,7 +766,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Nov – Apr (Australian/South Pacific cyclone season)",
+      "hurricane_season": "Nov \u2013 Apr (Australian/South Pacific cyclone season)",
       "peak_risk_months": [
         "Jan",
         "Feb",
@@ -872,7 +872,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "65-85°F year-round tropical",
+      "temp_range": "65-85\u00b0F year-round tropical",
       "humidity": "Moderate to high",
       "rain": "Wetter Dec-Mar; drier Jun-Oct",
       "wind": "Trade winds",
@@ -915,20 +915,20 @@
     "catches_off_guard": [
       "Aitutaki has possibly the most beautiful lagoon in the world",
       "One Foot Island is the iconic postcard shot",
-      "The island is tiny — you can drive around it in 30 minutes",
+      "The island is tiny \u2014 you can drive around it in 30 minutes",
       "Cook Islands use NZ dollar but have their own coins",
-      "Sunday is observed — limited activities"
+      "Sunday is observed \u2014 limited activities"
     ],
     "packing_nudges": [
       "Light beach clothing",
       "Reef-safe sunscreen",
       "Snorkel gear",
       "Water shoes for coral",
-      "Cash — limited ATMs"
+      "Cash \u2014 limited ATMs"
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Nov – Apr (South Pacific cyclone season)",
+      "hurricane_season": "Nov \u2013 Apr (South Pacific cyclone season)",
       "peak_risk_months": [
         "Jan",
         "Feb",
@@ -1034,7 +1034,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "39-84°F — Napoleon's birthplace",
+      "temp_range": "39-84\u00b0F \u2014 Napoleon's birthplace",
       "humidity": "Moderate (52-72%)",
       "rain": "Dry summers; wetter autumn/winter",
       "wind": "Can be gusty; Corsican mountains channel wind",
@@ -1069,8 +1069,8 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "Napoleon was born here — museums dedicated to him",
-      "Corsican identity is strong — not 'French' to locals",
+      "Napoleon was born here \u2014 museums dedicated to him",
+      "Corsican identity is strong \u2014 not 'French' to locals",
       "Calanques de Piana (red cliffs) are extraordinary",
       "Maquis (scrubland) scent is distinctive",
       "Chestnut and wild boar feature in local cuisine"
@@ -1184,7 +1184,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "31-70°F — French colonial village in volcanic harbor",
+      "temp_range": "31-70\u00b0F \u2014 French colonial village in volcanic harbor",
       "humidity": "Moderate",
       "rain": "Moderate year-round",
       "wind": "Sheltered harbor; calmer than open coast",
@@ -1223,10 +1223,10 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "Akaroa is a former French settlement — unique in NZ",
+      "Akaroa is a former French settlement \u2014 unique in NZ",
       "Hector's dolphins (world's smallest) are found only here",
-      "The harbor is a volcanic crater — dramatically scenic",
-      "Small town with limited facilities — don't expect big-city amenities",
+      "The harbor is a volcanic crater \u2014 dramatically scenic",
+      "Small town with limited facilities \u2014 don't expect big-city amenities",
       "French-influenced bakeries and cuisine set it apart"
     ],
     "packing_nudges": [
@@ -1338,7 +1338,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "21-59°F — subarctic but surprisingly mild",
+      "temp_range": "21-59\u00b0F \u2014 subarctic but surprisingly mild",
       "humidity": "Moderate",
       "rain": "Distributed; snow in winter",
       "wind": "Can be strong; sheltered fjord location helps",
@@ -1377,9 +1377,9 @@
     ],
     "catches_off_guard": [
       "Akureyri is Iceland's second city but feels like a small town",
-      "Goðafoss waterfall is 30 min drive — spectacular",
+      "Go\u00f0afoss waterfall is 30 min drive \u2014 spectacular",
       "Midnight sun in June-July means 24-hour daylight",
-      "Whale watching from Húsavík (1 hour) is world-class",
+      "Whale watching from H\u00fasav\u00edk (1 hour) is world-class",
       "The Arctic Botanical Garden is surprisingly lush"
     ],
     "packing_nudges": [
@@ -1491,7 +1491,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "28-63°F — Art Nouveau town",
+      "temp_range": "28-63\u00b0F \u2014 Art Nouveau town",
       "humidity": "High (69-80%)",
       "rain": "Wet year-round; slightly drier May-Jun",
       "wind": "Exposed Atlantic coast",
@@ -1534,7 +1534,7 @@
       "Town is walkable and compact"
     ],
     "packing_nudges": [
-      "Waterproof jacket — essential",
+      "Waterproof jacket \u2014 essential",
       "Warm layers",
       "Sturdy shoes for steps and trails",
       "Camera for architecture"
@@ -1642,7 +1642,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "50-88°F Mediterranean climate",
+      "temp_range": "50-88\u00b0F Mediterranean climate",
       "humidity": "Moderate; higher summer",
       "rain": "Winter rain (Dec-Feb); dry summers",
       "wind": "Can be strong along the Corniche",
@@ -1686,7 +1686,7 @@
     ],
     "catches_off_guard": [
       "The new Bibliotheca Alexandrina is air-conditioned and world-class",
-      "Pompey's Pillar and Catacombs are open-air — pick cooler days",
+      "Pompey's Pillar and Catacombs are open-air \u2014 pick cooler days",
       "Summer is hot and humid along the coast",
       "Winter can be surprisingly rainy and cool",
       "Egyptian cotton shopping is a unique opportunity"
@@ -1801,7 +1801,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "40-84°F — stunning coastal setting",
+      "temp_range": "40-84\u00b0F \u2014 stunning coastal setting",
       "humidity": "Moderate (50-76%)",
       "rain": "Wet Oct-Feb; dry summers",
       "wind": "Protected by cliffs but funnel effect possible",
@@ -1839,8 +1839,8 @@
     ],
     "catches_off_guard": [
       "Path of the Gods hike is bucket-list worthy",
-      "Amalfi Coast road is one-lane in places — terrifying and beautiful",
-      "Tender from ship — dependent on sea state",
+      "Amalfi Coast road is one-lane in places \u2014 terrifying and beautiful",
+      "Tender from ship \u2014 dependent on sea state",
       "Positano is a steep descent of 1000+ steps",
       "Paper-making tradition dates to medieval times"
     ],
@@ -1953,7 +1953,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "69-89°F year-round",
+      "temp_range": "69-89\u00b0F year-round",
       "humidity": "Moderate (71-79%)",
       "rain": "Two wet periods: May-Jun and Sep-Nov",
       "wind": "Trades; sheltered bay",
@@ -1993,7 +1993,7 @@
       "Oct"
     ],
     "catches_off_guard": [
-      "Purpose-built port — limited authentic experience at pier",
+      "Purpose-built port \u2014 limited authentic experience at pier",
       "Puerto Plata town worth the taxi ride",
       "27 Waterfalls of Damajagua is must-do excursion",
       "Much sold amber is synthetic",
@@ -2007,7 +2007,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Sep",
         "Oct"
@@ -2113,7 +2113,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "32-71°F — maritime, cool summers",
+      "temp_range": "32-71\u00b0F \u2014 maritime, cool summers",
       "humidity": "High (71-87%)",
       "rain": "Year-round; slightly less Apr-Jun",
       "wind": "Frequent; North Sea influence",
@@ -2156,13 +2156,13 @@
     ],
     "catches_off_guard": [
       "Canal tours reveal the city better than walking",
-      "Anne Frank House requires timed tickets — book weeks ahead",
+      "Anne Frank House requires timed tickets \u2014 book weeks ahead",
       "King's Day (Apr 27) is massive orange street party",
-      "Cycling traffic is aggressive — stay out of bike lanes",
+      "Cycling traffic is aggressive \u2014 stay out of bike lanes",
       "Van Gogh Museum and Rijksmuseum both need advance booking"
     ],
     "packing_nudges": [
-      "Rain jacket — essential year-round",
+      "Rain jacket \u2014 essential year-round",
       "Layers for changeable weather",
       "Comfortable walking shoes",
       "Museum tickets pre-booked"
@@ -2270,7 +2270,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "8-65°F — subarctic continental",
+      "temp_range": "8-65\u00b0F \u2014 subarctic continental",
       "humidity": "Moderate; drier than coast",
       "rain": "Relatively dry; wettest Aug-Oct",
       "wind": "Moderate; chinook winds bring warmth",
@@ -2312,10 +2312,10 @@
     ],
     "catches_off_guard": [
       "Anchorage is the starting/ending point for many Alaska cruises",
-      "In summer, daylight lasts 19+ hours — bring an eye mask",
+      "In summer, daylight lasts 19+ hours \u2014 bring an eye mask",
       "The Seward Highway to the port is one of America's most scenic drives",
       "Tony Knowles Coastal Trail offers easy hiking with mountain views",
-      "Moose wander through neighborhoods — keep your distance"
+      "Moose wander through neighborhoods \u2014 keep your distance"
     ],
     "packing_nudges": [
       "Warm layers even in summer",
@@ -2426,7 +2426,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "10-37°F — Antarctic maritime",
+      "temp_range": "10-37\u00b0F \u2014 Antarctic maritime",
       "humidity": "High; maritime influence",
       "rain": "Snow and sleet year-round; slightly drier in winter",
       "wind": "Very strong; katabatic winds",
@@ -2467,9 +2467,9 @@
       "Oct"
     ],
     "catches_off_guard": [
-      "Antarctic expeditions are once-in-a-lifetime — emotionally overwhelming",
-      "Penguin colonies are enormous — chinstrap, gentoo, and Adélie",
-      "Leopard seals patrol penguin colonies — dramatic wildlife watching",
+      "Antarctic expeditions are once-in-a-lifetime \u2014 emotionally overwhelming",
+      "Penguin colonies are enormous \u2014 chinstrap, gentoo, and Ad\u00e9lie",
+      "Leopard seals patrol penguin colonies \u2014 dramatic wildlife watching",
       "Weather can change from sunshine to whiteout in minutes",
       "The Drake Passage crossing (2 days each way) can be extremely rough"
     ],
@@ -2583,7 +2583,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "10-37°F — Antarctic continent",
+      "temp_range": "10-37\u00b0F \u2014 Antarctic continent",
       "humidity": "High near coast; dry interior",
       "rain": "Snow year-round; precipitation light overall",
       "wind": "Extreme katabatic winds possible",
@@ -2618,7 +2618,7 @@
     ],
     "catches_off_guard": [
       "Antarctica is the coldest, driest, windiest continent",
-      "Cruise season is Nov-Mar only — expeditions depart from Ushuaia",
+      "Cruise season is Nov-Mar only \u2014 expeditions depart from Ushuaia",
       "IAATO regulations limit visitor numbers to protect the environment",
       "You must stay 5 meters from wildlife (they may approach you)",
       "The silence and scale are genuinely life-changing"
@@ -2733,7 +2733,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "72-89°F year-round",
+      "temp_range": "72-89\u00b0F year-round",
       "humidity": "Moderate (68-76%)",
       "rain": "Drier Jan-Apr; wetter Jul-Nov",
       "wind": "Persistent trades",
@@ -2777,11 +2777,11 @@
       "Sep"
     ],
     "catches_off_guard": [
-      "365 beaches — genuinely varied",
+      "365 beaches \u2014 genuinely varied",
       "Sailing Week (late Apr) fills island",
       "Nelson's Dockyard requires transport",
       "Roads narrow, driving on left",
-      "Limited water supply — conservation matters"
+      "Limited water supply \u2014 conservation matters"
     ],
     "packing_nudges": [
       "Reef-safe sunscreen",
@@ -2791,7 +2791,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Aug",
         "Sep",
@@ -2898,7 +2898,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "72-86°F year-round tropical",
+      "temp_range": "72-86\u00b0F year-round tropical",
       "humidity": "High year-round",
       "rain": "Wet season Nov-Apr; drier May-Oct",
       "wind": "Trade winds; occasional cyclones",
@@ -2941,11 +2941,11 @@
       "Mar"
     ],
     "catches_off_guard": [
-      "Samoa is deeply traditional — Sunday is strictly observed",
+      "Samoa is deeply traditional \u2014 Sunday is strictly observed",
       "Robert Louis Stevenson's home (Vailima) is a museum",
       "To Sua Ocean Trench is one of the most photogenic spots in the Pacific",
       "Samoan tattoo (pe'a) is a sacred cultural practice",
-      "The international date line was moved — Samoa skipped a day in 2011"
+      "The international date line was moved \u2014 Samoa skipped a day in 2011"
     ],
     "packing_nudges": [
       "Light breathable clothing",
@@ -2956,7 +2956,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Nov – Apr (South Pacific cyclone season)",
+      "hurricane_season": "Nov \u2013 Apr (South Pacific cyclone season)",
       "peak_risk_months": [
         "Jan",
         "Feb",
@@ -3062,8 +3062,8 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "49-103°F wide desert range",
-      "humidity": "Very low — arid desert climate",
+      "temp_range": "49-103\u00b0F wide desert range",
+      "humidity": "Very low \u2014 arid desert climate",
       "rain": "Virtually none",
       "wind": "Hot desert winds in summer; pleasant winter breezes",
       "daylight": "10-14 hours seasonal"
@@ -3107,8 +3107,8 @@
       "Aug"
     ],
     "catches_off_guard": [
-      "Petra is a 2-hour drive — an all-day excursion in desert heat",
-      "Summer heat makes Petra dangerous — start at dawn if visiting",
+      "Petra is a 2-hour drive \u2014 an all-day excursion in desert heat",
+      "Summer heat makes Petra dangerous \u2014 start at dawn if visiting",
       "Red Sea visibility is excellent year-round",
       "Wadi Rum excursions are spectacular but require sun protection",
       "The dry air means sunburn happens faster than expected"
@@ -3222,8 +3222,8 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "76-91°F — remarkably consistent",
-      "humidity": "Low to moderate (60-70%) — driest Caribbean island",
+      "temp_range": "76-91\u00b0F \u2014 remarkably consistent",
+      "humidity": "Low to moderate (60-70%) \u2014 driest Caribbean island",
       "rain": "Very little; brief showers Oct-Dec",
       "wind": "Constant trades (15-25 mph)",
       "daylight": "11.5-12.5 hours"
@@ -3258,14 +3258,14 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "Wind is constant — hats fly away",
+      "Wind is constant \u2014 hats fly away",
       "Outside the main hurricane belt",
       "Low humidity feels cooler than other islands",
       "North coast waves dangerous",
       "Natural pool hike needs sturdy shoes"
     ],
     "packing_nudges": [
-      "Sunscreen — breeze masks sunburn",
+      "Sunscreen \u2014 breeze masks sunburn",
       "Windbreaker for evenings",
       "Water shoes",
       "Hat with chin strap"
@@ -3373,9 +3373,9 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "67-86°F year-round tropical oceanic",
+      "temp_range": "67-86\u00b0F year-round tropical oceanic",
       "humidity": "Moderate",
-      "rain": "Very little — volcanic island",
+      "rain": "Very little \u2014 volcanic island",
       "wind": "Southeast trade winds constant",
       "daylight": "11-13 hours seasonal"
     },
@@ -3410,8 +3410,8 @@
       "Green Mountain is a unique artificial cloud forest on a volcanic island",
       "Sea turtle nesting season is Dec-May",
       "The island is a UK Overseas Territory with military presence",
-      "No commercial airport until recently — very remote",
-      "Georgetown is tiny — everything is walkable"
+      "No commercial airport until recently \u2014 very remote",
+      "Georgetown is tiny \u2014 everything is walkable"
     ],
     "packing_nudges": [
       "Light breathable clothing",
@@ -3522,7 +3522,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "55-91°F; very hot dry summers, mild wet winters",
+      "temp_range": "55-91\u00b0F; very hot dry summers, mild wet winters",
       "humidity": "Low in summer (45-50%), Moderate in winter (67-72%)",
       "rain": "Virtually no rain Jun-Aug; wettest Nov-Feb",
       "wind": "Meltemi winds provide some relief in summer",
@@ -3566,17 +3566,17 @@
       "Aug"
     ],
     "catches_off_guard": [
-      "July-August heat at Acropolis is dangerous (100°F+ with no shade)",
-      "Piraeus port is 30-45 min from Athens center — factor in transit time",
-      "Acropolis has extremely uneven marble — many falls/injuries",
-      "No shade at ruins — heat exhaustion and sunburn are common",
+      "July-August heat at Acropolis is dangerous (100\u00b0F+ with no shade)",
+      "Piraeus port is 30-45 min from Athens center \u2014 factor in transit time",
+      "Acropolis has extremely uneven marble \u2014 many falls/injuries",
+      "No shade at ruins \u2014 heat exhaustion and sunburn are common",
       "August is extremely crowded and many Athenians leave the city",
       "Strikes (transport, museums) can happen without much warning"
     ],
     "packing_nudges": [
       "Shoes with excellent traction (Acropolis marble is treacherous)",
       "Sun hat, sunglasses, and high-SPF sunscreen",
-      "Water bottle (bring to Acropolis — limited fountains)",
+      "Water bottle (bring to Acropolis \u2014 limited fountains)",
       "Modest clothing for monasteries and churches",
       "Early morning Acropolis tickets (beat heat and crowds)",
       "Electrolyte packets for summer visits"
@@ -3684,10 +3684,10 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "44-74°F mild maritime year-round",
+      "temp_range": "44-74\u00b0F mild maritime year-round",
       "humidity": "Moderate to high year-round",
       "rain": "Distributed year-round; slightly drier in summer",
-      "wind": "Can be windy — 'City of Sails'",
+      "wind": "Can be windy \u2014 'City of Sails'",
       "daylight": "9.5-15 hours (Southern Hemisphere)"
     },
     "best_months_for": {
@@ -3722,13 +3722,13 @@
     "avoid_months": [],
     "catches_off_guard": [
       "Auckland's weather can change 4 times in one day",
-      "Sky Tower views are weather-dependent — go on clear days",
+      "Sky Tower views are weather-dependent \u2014 go on clear days",
       "Rangitoto Island is a volcanic cone hike with no shade",
       "Waiheke Island (ferry) has excellent wineries",
-      "New Zealand UV is extreme due to thin ozone — sunburn happens fast"
+      "New Zealand UV is extreme due to thin ozone \u2014 sunburn happens fast"
     ],
     "packing_nudges": [
-      "Layers — weather changes rapidly",
+      "Layers \u2014 weather changes rapidly",
       "Waterproof jacket",
       "Sunscreen SPF 50+",
       "Comfortable walking shoes",
@@ -3836,7 +3836,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "73-88°F year-round tropical",
+      "temp_range": "73-88\u00b0F year-round tropical",
       "humidity": "Moderate to high; driest Jul-Sep",
       "rain": "Wet season Nov-Mar; dry season Apr-Oct",
       "wind": "Light; offshore breezes",
@@ -3886,7 +3886,7 @@
       "Bali's dry season (Apr-Oct) is dramatically better than wet season",
       "Wet season brings daily torrential downpours and humidity",
       "Ubud's rice terraces are lush green in wet season but muddy",
-      "Nyepi (Day of Silence, usually March) shuts down the entire island — including the airport",
+      "Nyepi (Day of Silence, usually March) shuts down the entire island \u2014 including the airport",
       "Temple dress codes require sarongs even in heat"
     ],
     "packing_nudges": [
@@ -3998,7 +3998,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "28-88°F — four distinct seasons",
+      "temp_range": "28-88\u00b0F \u2014 four distinct seasons",
       "humidity": "Moderate; muggy summers",
       "rain": "Distributed year-round; slightly drier fall",
       "wind": "Moderate",
@@ -4047,7 +4047,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Sep",
         "Oct"
@@ -4152,7 +4152,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "71-95°F year-round heat",
+      "temp_range": "71-95\u00b0F year-round heat",
       "humidity": "Moderate dry season; high wet season",
       "rain": "Wet season May-Oct; dry Nov-Apr",
       "wind": "Light monsoon winds",
@@ -4196,7 +4196,7 @@
     "catches_off_guard": [
       "Bangkok's port (Laem Chabang) is 2+ hours from the city center",
       "Wet season floods can paralyze traffic for hours",
-      "The heat index frequently exceeds 110°F in April",
+      "The heat index frequently exceeds 110\u00b0F in April",
       "Songkran water festival (mid-April) means you will get soaked",
       "Afternoon monsoon rains often cause flash flooding"
     ],
@@ -4209,7 +4209,7 @@
     ],
     "hazards": {
       "hurricane_zone": false,
-      "note": "Wet season floods can paralyze traffic for hours. The heat index frequently exceeds 110°F in April. Afternoon monsoon rains often cause flash flooding."
+      "note": "Wet season floods can paralyze traffic for hours. The heat index frequently exceeds 110\u00b0F in April. Afternoon monsoon rains often cause flash flooding."
     },
     "cruise_seasons": {
       "high": [
@@ -4310,7 +4310,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "15-78°F — Maine coastal",
+      "temp_range": "15-78\u00b0F \u2014 Maine coastal",
       "humidity": "Moderate; foggy summers",
       "rain": "Distributed; fog common Jun-Aug",
       "wind": "Can be strong; exposed coast",
@@ -4353,9 +4353,9 @@
       "Mar"
     ],
     "catches_off_guard": [
-      "Acadia National Park is the main attraction — arrive early for Cadillac Mountain",
-      "Bar Island is walkable at low tide — check tide tables!",
-      "Fog can roll in quickly — always bring a jacket",
+      "Acadia National Park is the main attraction \u2014 arrive early for Cadillac Mountain",
+      "Bar Island is walkable at low tide \u2014 check tide tables!",
+      "Fog can roll in quickly \u2014 always bring a jacket",
       "The town is tiny but charming with excellent restaurants",
       "Jordan Pond House popovers are a tradition"
     ],
@@ -4368,7 +4368,7 @@
     ],
     "hazards": {
       "hurricane_zone": false,
-      "note": "Bar Island is walkable at low tide — check tide tables. Fog can roll in quickly — always bring a jacket."
+      "note": "Bar Island is walkable at low tide \u2014 check tide tables. Fog can roll in quickly \u2014 always bring a jacket."
     },
     "cruise_seasons": {
       "high": [
@@ -4469,7 +4469,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "72-88°F year-round",
+      "temp_range": "72-88\u00b0F year-round",
       "humidity": "Moderate to high (68-78%)",
       "rain": "Dry Jan-May; wet Jun-Nov",
       "wind": "Strong easterlies year-round",
@@ -4508,8 +4508,8 @@
       "Oct"
     ],
     "catches_off_guard": [
-      "East coast has dangerous currents — west coast only",
-      "Further east — longer sail from US",
+      "East coast has dangerous currents \u2014 west coast only",
+      "Further east \u2014 longer sail from US",
       "Rum punch stronger than it tastes",
       "Driving on the LEFT",
       "Fierce sun even through clouds"
@@ -4522,7 +4522,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Sep",
         "Oct"
@@ -4628,8 +4628,8 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "57-82°F; hot dry summers, mild winters",
-      "humidity": "Moderate (65-70%) — comfortable Mediterranean climate",
+      "temp_range": "57-82\u00b0F; hot dry summers, mild winters",
+      "humidity": "Moderate (65-70%) \u2014 comfortable Mediterranean climate",
       "rain": "Wettest in spring and fall; summers very dry",
       "wind": "Sea breezes moderate summer heat; Tramuntana winds occasional",
       "daylight": "9-15 hours; long summer evenings perfect for exploring"
@@ -4792,7 +4792,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "42-77°F subtropical for NZ",
+      "temp_range": "42-77\u00b0F subtropical for NZ",
       "humidity": "Moderate to high",
       "rain": "Distributed year-round; slightly drier summer",
       "wind": "Light to moderate",
@@ -4832,18 +4832,18 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "Waitangi Treaty Grounds are historically significant — allow time",
+      "Waitangi Treaty Grounds are historically significant \u2014 allow time",
       "Hole in the Rock cruise is weather-dependent",
       "Swimming with dolphins is a unique experience",
-      "Russell (across the bay) is NZ's first capital — charming",
-      "This is NZ's subtropical north — warmest cruise port"
+      "Russell (across the bay) is NZ's first capital \u2014 charming",
+      "This is NZ's subtropical north \u2014 warmest cruise port"
     ],
     "packing_nudges": [
       "Layers for variable weather",
       "Waterproof jacket",
       "Sunscreen SPF 50+",
       "Comfortable walking shoes",
-      "Swimwear — beaches are beautiful"
+      "Swimwear \u2014 beaches are beautiful"
     ],
     "hazards": {
       "hurricane_zone": false
@@ -4947,7 +4947,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "16-90°F extreme continental range",
+      "temp_range": "16-90\u00b0F extreme continental range",
       "humidity": "Low winter, muggy summer",
       "rain": "Concentrated Jul-Aug monsoon rains; dry winters",
       "wind": "Dusty spring winds Mar-May",
@@ -4990,7 +4990,7 @@
     ],
     "catches_off_guard": [
       "Spring dust storms can ground flights and reduce visibility to near zero",
-      "Summer is brutally hot and humid — the Forbidden City has no shade",
+      "Summer is brutally hot and humid \u2014 the Forbidden City has no shade",
       "Winter lows can hit single digits Fahrenheit",
       "Air quality varies dramatically day to day",
       "The port (Tianjin) is 2+ hours from Beijing proper"
@@ -5000,7 +5000,7 @@
       "Breathable clothing for summer",
       "Dust mask for spring visits",
       "Sunscreen and hat",
-      "Comfortable walking shoes — sites are enormous"
+      "Comfortable walking shoes \u2014 sites are enormous"
     ],
     "hazards": {
       "hurricane_zone": false
@@ -5104,7 +5104,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "34-66°F — Northern Ireland, mild but wet",
+      "temp_range": "34-66\u00b0F \u2014 Northern Ireland, mild but wet",
       "humidity": "High (72-84%)",
       "rain": "Wet year-round",
       "wind": "Atlantic influence",
@@ -5147,14 +5147,14 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "Titanic Belfast is world-class museum — allow 3 hours",
-      "Giant's Causeway is 1.5 hours north — popular excursion",
-      "Political murals tell complex history — taxi tours available",
+      "Titanic Belfast is world-class museum \u2014 allow 3 hours",
+      "Giant's Causeway is 1.5 hours north \u2014 popular excursion",
+      "Political murals tell complex history \u2014 taxi tours available",
       "Cathedral Quarter has best restaurants and nightlife",
       "Game of Thrones filming locations accessible as day trips"
     ],
     "packing_nudges": [
-      "Waterproof jacket — essential",
+      "Waterproof jacket \u2014 essential",
       "Layers",
       "Comfortable walking shoes",
       "Cash for Black Taxi tours"
@@ -5262,7 +5262,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "70-89°F year-round",
+      "temp_range": "70-89\u00b0F year-round",
       "humidity": "High (77-84%)",
       "rain": "Dry Feb-May; very wet Jun-Nov",
       "wind": "Sea breezes; calm in fall",
@@ -5303,14 +5303,14 @@
       "Some neighborhoods outside tourist area are rough"
     ],
     "packing_nudges": [
-      "Bug repellent — essential",
+      "Bug repellent \u2014 essential",
       "Reef-safe sunscreen",
       "Quick-dry clothing",
       "Cash for water taxis"
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Sep",
         "Oct"
@@ -5416,8 +5416,8 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "39-66°F; cool year-round, one of Europe's wettest cities",
-      "humidity": "High (72-84%) — constant dampness from rain",
+      "temp_range": "39-66\u00b0F; cool year-round, one of Europe's wettest cities",
+      "humidity": "High (72-84%) \u2014 constant dampness from rain",
       "rain": "Rains 200+ days per year; wettest Sep-Jan, but rain anytime",
       "wind": "Moderate coastal breezes; fjords can create gusty conditions",
       "daylight": "6-19 hours; midnight sun in Jun, dark winters"
@@ -5463,15 +5463,15 @@
       "Jan"
     ],
     "catches_off_guard": [
-      "Bergen is ALWAYS wet — it rains 200+ days per year, even in 'summer'",
-      "66°F is peak summer heat — bring warm layers year-round",
+      "Bergen is ALWAYS wet \u2014 it rains 200+ days per year, even in 'summer'",
+      "66\u00b0F is peak summer heat \u2014 bring warm layers year-round",
       "Fjord tours in rain/fog miss the scenery",
-      "Rain gear is not optional — it will rain during your visit",
-      "Extremely expensive city (coffee €7+, meals €30+)",
+      "Rain gear is not optional \u2014 it will rain during your visit",
+      "Extremely expensive city (coffee \u20ac7+, meals \u20ac30+)",
       "July is peak tourist season but also very rainy"
     ],
     "packing_nudges": [
-      "Waterproof jacket and pants (seriously — not water-resistant, waterproof)",
+      "Waterproof jacket and pants (seriously \u2014 not water-resistant, waterproof)",
       "Waterproof hiking boots if doing any excursions",
       "Warm fleece or wool layers even in July",
       "Waterproof bag for electronics/valuables",
@@ -5581,7 +5581,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "57-86°F — distinct seasons unlike Caribbean",
+      "temp_range": "57-86\u00b0F \u2014 distinct seasons unlike Caribbean",
       "humidity": "Moderate (71-80%)",
       "rain": "Year-round; slightly drier Apr-Jun",
       "wind": "Can be very windy; winter gales",
@@ -5627,7 +5627,7 @@
       "Feb"
     ],
     "catches_off_guard": [
-      "NOT tropical — winter is cool (60s) and grey",
+      "NOT tropical \u2014 winter is cool (60s) and grey",
       "Water doesn't warm until late May",
       "Pink sand beaches real but small",
       "Late-season hurricanes (Oct) are the risk",
@@ -5641,7 +5641,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Sep",
         "Oct"
@@ -5747,7 +5747,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "39-76°F — Basque Country, green and mild",
+      "temp_range": "39-76\u00b0F \u2014 Basque Country, green and mild",
       "humidity": "Moderate to high (66-74%)",
       "rain": "Wet year-round; drier Jun-Aug",
       "wind": "Atlantic; sheltered by mountains somewhat",
@@ -5786,7 +5786,7 @@
     ],
     "catches_off_guard": [
       "Guggenheim Museum is architecturally stunning",
-      "Pintxos (Basque tapas) culture is exceptional — bar hop",
+      "Pintxos (Basque tapas) culture is exceptional \u2014 bar hop",
       "Casco Viejo (old town) is compact and walkable",
       "Basque culture is distinct from Spanish",
       "San Juan de Gaztelugatxe (Dragonstone from GoT) is day trip"
@@ -5794,7 +5794,7 @@
     "packing_nudges": [
       "Waterproof jacket",
       "Comfortable walking shoes",
-      "Layers — weather changes quickly",
+      "Layers \u2014 weather changes quickly",
       "Cash for pintxos bars"
     ],
     "hazards": {
@@ -5900,7 +5900,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "66-90°F year-round",
+      "temp_range": "66-90\u00b0F year-round",
       "humidity": "Moderate (68-78%)",
       "rain": "Brief showers; wetter Jun-Oct",
       "wind": "Trades; Gulf Stream proximity",
@@ -5940,7 +5940,7 @@
       "Only 50 miles from Miami",
       "Hemingway wrote here in the 1930s",
       "Resort Beach Club separate from village",
-      "Gulf Stream — great for sportfishing",
+      "Gulf Stream \u2014 great for sportfishing",
       "Small island, limited transport"
     ],
     "packing_nudges": [
@@ -5951,7 +5951,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Sep",
         "Oct"
@@ -6057,7 +6057,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "43-90°F — Turkish Riviera",
+      "temp_range": "43-90\u00b0F \u2014 Turkish Riviera",
       "humidity": "Low to moderate (33-67%)",
       "rain": "Bone-dry Jun-Sep; wet winters",
       "wind": "Meltemi in summer; gusty",
@@ -6104,7 +6104,7 @@
       "Bodrum mandarin oranges are famous locally"
     ],
     "packing_nudges": [
-      "Sunscreen — intense summer UV",
+      "Sunscreen \u2014 intense summer UV",
       "Wind-resistant hat",
       "Comfortable shoes for castle",
       "Cash for bazaar shopping"
@@ -6212,7 +6212,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "75-90°F year-round",
+      "temp_range": "75-90\u00b0F year-round",
       "humidity": "Low to moderate (64-70%)",
       "rain": "Very little; brief Oct-Jan",
       "wind": "Strong constant trades",
@@ -6254,14 +6254,14 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "World-class shore diving — walk right in",
+      "World-class shore diving \u2014 walk right in",
       "Entire coastline is marine park",
-      "Extremely dry — carry water everywhere",
-      "Wind relentless — east coast gets sand blasts",
+      "Extremely dry \u2014 carry water everywhere",
+      "Wind relentless \u2014 east coast gets sand blasts",
       "Limited restaurants compared to Aruba/Curacao"
     ],
     "packing_nudges": [
-      "Reef-safe sunscreen — mandatory",
+      "Reef-safe sunscreen \u2014 mandatory",
       "Water shoes for coral entries",
       "Reusable water bottle",
       "Dive/snorkel gear (rentals limited)"
@@ -6369,7 +6369,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "72-87°F year-round tropical paradise",
+      "temp_range": "72-87\u00b0F year-round tropical paradise",
       "humidity": "High year-round; slightly lower Jun-Sep",
       "rain": "Wet season Nov-Apr; drier May-Oct",
       "wind": "Light trade winds",
@@ -6416,9 +6416,9 @@
       "Mar"
     ],
     "catches_off_guard": [
-      "Bora Bora is a tender port — small boats take you ashore",
+      "Bora Bora is a tender port \u2014 small boats take you ashore",
       "Overwater bungalows are the main resort experience but cruise passengers won't use them",
-      "The lagoon is the attraction — rent a kayak or take a tour",
+      "The lagoon is the attraction \u2014 rent a kayak or take a tour",
       "Mt. Otemanu is photogenic from every angle",
       "Prices are eye-wateringly expensive for everything"
     ],
@@ -6431,7 +6431,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Nov – Apr (South Pacific cyclone season)",
+      "hurricane_season": "Nov \u2013 Apr (South Pacific cyclone season)",
       "peak_risk_months": [
         "Jan",
         "Feb",
@@ -6537,7 +6537,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "35-79°F — wine country, oceanic climate",
+      "temp_range": "35-79\u00b0F \u2014 wine country, oceanic climate",
       "humidity": "Moderate to high (64-84%)",
       "rain": "Year-round; slightly drier summer",
       "wind": "Atlantic influence",
@@ -6574,15 +6574,15 @@
       "Feb"
     ],
     "catches_off_guard": [
-      "River port — ship navigates Garonne estuary",
-      "Wine châteaux visits require advance booking",
+      "River port \u2014 ship navigates Garonne estuary",
+      "Wine ch\u00e2teaux visits require advance booking",
       "Place de la Bourse water mirror is stunning",
       "City centre is UNESCO World Heritage",
-      "Canelé pastry is the local specialty"
+      "Canel\u00e9 pastry is the local specialty"
     ],
     "packing_nudges": [
       "Comfortable walking shoes",
-      "Wine-appropriate clothing for château visits",
+      "Wine-appropriate clothing for ch\u00e2teau visits",
       "Light rain jacket",
       "Cash for market shopping"
     ],
@@ -6689,8 +6689,8 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "37-82°F; true four seasons, cold snowy winters, hot summers",
-      "humidity": "Moderate (58-66%) — comfortable except muggy summer days",
+      "temp_range": "37-82\u00b0F; true four seasons, cold snowy winters, hot summers",
+      "humidity": "Moderate (58-66%) \u2014 comfortable except muggy summer days",
       "rain": "Consistent year-round; winter brings snow instead of rain",
       "wind": "Coastal winds can be brutal in winter ('Windy City' of East)",
       "daylight": "9-15 hours; crisp fall days, long summer evenings"
@@ -6731,10 +6731,10 @@
     ],
     "catches_off_guard": [
       "Winter can be brutally cold with nor'easters (snow/ice storms)",
-      "Summer can be hot and humid (80-90°F with muggy air)",
-      "Fall foliage peaks mid-Oct — absolutely spectacular but crowded",
+      "Summer can be hot and humid (80-90\u00b0F with muggy air)",
+      "Fall foliage peaks mid-Oct \u2014 absolutely spectacular but crowded",
       "Traffic and drivers are notoriously aggressive",
-      "Port is right downtown — easy walking to attractions",
+      "Port is right downtown \u2014 easy walking to attractions",
       "Weather changes rapidly year-round"
     ],
     "packing_nudges": [
@@ -6848,7 +6848,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "45-85°F subtropical",
+      "temp_range": "45-85\u00b0F subtropical",
       "humidity": "Moderate; drier winter",
       "rain": "Wetter summer (Dec-Mar); dry sunny winters",
       "wind": "Sea breezes; occasional summer storms",
@@ -6891,7 +6891,7 @@
     "avoid_months": [],
     "catches_off_guard": [
       "Summer thunderstorms can be intense with large hail",
-      "Lone Pine Koala Sanctuary is a top excursion — open year-round",
+      "Lone Pine Koala Sanctuary is a top excursion \u2014 open year-round",
       "South Bank has a free man-made beach and parklands",
       "Winter is essentially a pleasant dry season with blue skies",
       "Gold Coast (1 hour south) has better beaches but crowds"
@@ -7006,7 +7006,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "75-88°F year-round equatorial",
+      "temp_range": "75-88\u00b0F year-round equatorial",
       "humidity": "Very high year-round (80-84%)",
       "rain": "Frequent year-round; wettest Oct-Jan",
       "wind": "Light",
@@ -7037,9 +7037,9 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "Brunei is a dry country — no alcohol sold",
+      "Brunei is a dry country \u2014 no alcohol sold",
       "The Omar Ali Saifuddien Mosque is spectacular but dress modestly",
-      "Kampong Ayer (water village) is the world's largest — worth exploring",
+      "Kampong Ayer (water village) is the world's largest \u2014 worth exploring",
       "Everything closes for Friday prayers",
       "The Sultan's palace is only open during Hari Raya celebrations"
     ],
@@ -7152,7 +7152,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "41-86°F — four seasons (Southern Hemisphere)",
+      "temp_range": "41-86\u00b0F \u2014 four seasons (Southern Hemisphere)",
       "humidity": "Moderate year-round",
       "rain": "Distributed year-round; slightly drier winter",
       "wind": "Pampero winds can bring sudden cold fronts",
@@ -7195,10 +7195,10 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "Buenos Aires summer (Dec-Feb) is hot and humid — many locals flee to the coast",
+      "Buenos Aires summer (Dec-Feb) is hot and humid \u2014 many locals flee to the coast",
       "Tango shows run year-round but outdoor milongas are seasonal",
-      "The city is huge — taxis and subte (metro) are essential",
-      "Argentine steak is legendary — budget time for a proper parrilla",
+      "The city is huge \u2014 taxis and subte (metro) are essential",
+      "Argentine steak is legendary \u2014 budget time for a proper parrilla",
       "Recoleta Cemetery (Evita's tomb) is a must-see"
     ],
     "packing_nudges": [
@@ -7210,7 +7210,7 @@
     ],
     "hazards": {
       "hurricane_zone": false,
-      "note": "Buenos Aires summer (Dec-Feb) is hot and humid — many locals flee to the coast."
+      "note": "Buenos Aires summer (Dec-Feb) is hot and humid \u2014 many locals flee to the coast."
     },
     "cruise_seasons": {
       "high": [
@@ -7311,7 +7311,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "31-85°F four seasons",
+      "temp_range": "31-85\u00b0F four seasons",
       "humidity": "Muggy Jul-Sep; dry crisp fall",
       "rain": "Monsoon rains Jul-Aug; dry winter",
       "wind": "Strong winter winds off the sea",
@@ -7355,7 +7355,7 @@
       "Jagalchi Fish Market is best visited in autumn for fresh catch",
       "Haeundae Beach gets extremely crowded in summer",
       "Winter winds off the sea are biting cold",
-      "Cherry blossoms arrive late March — earlier than Tokyo"
+      "Cherry blossoms arrive late March \u2014 earlier than Tokyo"
     ],
     "packing_nudges": [
       "Warm layers for winter (windproof)",
@@ -7366,7 +7366,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "May – Nov (Western Pacific typhoon season)",
+      "hurricane_season": "May \u2013 Nov (Western Pacific typhoon season)",
       "peak_risk_months": [
         "Aug",
         "Sep",
@@ -7472,10 +7472,10 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "61-86°F year-round warm",
+      "temp_range": "61-86\u00b0F year-round warm",
       "humidity": "Moderate to high",
       "rain": "Wetter Nov-Mar; dry Jun-Sep",
-      "wind": "Consistent breezes — popular for windsurfing",
+      "wind": "Consistent breezes \u2014 popular for windsurfing",
       "daylight": "10.5-13.5 hours (Southern Hemisphere)"
     },
     "best_months_for": {
@@ -7507,11 +7507,11 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "Búzios was made famous by Brigitte Bardot in the 1960s",
+      "B\u00fazios was made famous by Brigitte Bardot in the 1960s",
       "Rua das Pedras is the main shopping and dining strip",
       "The peninsula has 20+ beaches, each with different character",
-      "It's a tender port — boats take you to the pier",
-      "Winter (Jun-Aug) is the best time — warm days, cool evenings, no rain"
+      "It's a tender port \u2014 boats take you to the pier",
+      "Winter (Jun-Aug) is the best time \u2014 warm days, cool evenings, no rain"
     ],
     "packing_nudges": [
       "Light beach clothing",
@@ -7622,7 +7622,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "58-95°F desert coastal with hot summers",
+      "temp_range": "58-95\u00b0F desert coastal with hot summers",
       "humidity": "Low; higher in hurricane season",
       "rain": "Almost none Nov-Jun; brief storms Jul-Oct",
       "wind": "Moderate; stronger in winter",
@@ -7668,11 +7668,11 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "El Arco (The Arch) is the iconic landmark — visible from most beaches",
-      "Whale watching (Dec-Mar) is world-class — humpbacks and gray whales",
+      "El Arco (The Arch) is the iconic landmark \u2014 visible from most beaches",
+      "Whale watching (Dec-Mar) is world-class \u2014 humpbacks and gray whales",
       "Lover's Beach is only accessible by water taxi",
       "The Sea of Cortez side has calmer waters than the Pacific side",
-      "This is a tender port — boat transfers to shore"
+      "This is a tender port \u2014 boat transfers to shore"
     ],
     "packing_nudges": [
       "Light beach clothing",
@@ -7683,7 +7683,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "May 15 – Nov 30 (East Pacific)",
+      "hurricane_season": "May 15 \u2013 Nov 30 (East Pacific)",
       "peak_risk_months": [
         "Aug",
         "Sep",
@@ -7789,7 +7789,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "46-87°F — hot dry summers, mild winters",
+      "temp_range": "46-87\u00b0F \u2014 hot dry summers, mild winters",
       "humidity": "Moderate (50-74%)",
       "rain": "Wet Oct-Jan; bone-dry Jun-Aug",
       "wind": "Levante (east) hot; Poniente (west) cool",
@@ -7827,9 +7827,9 @@
     ],
     "catches_off_guard": [
       "One of oldest cities in Western Europe",
-      "Summer heat can exceed 100°F with Levante wind",
+      "Summer heat can exceed 100\u00b0F with Levante wind",
       "Carnival (Feb) is second only to Rio",
-      "Cathedral views are stunning — worth the climb",
+      "Cathedral views are stunning \u2014 worth the climb",
       "Tapas culture is authentic and affordable"
     ],
     "packing_nudges": [
@@ -7941,7 +7941,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "42-87°F — Sardinia's sunny capital",
+      "temp_range": "42-87\u00b0F \u2014 Sardinia's sunny capital",
       "humidity": "Moderate (48-75%)",
       "rain": "Dry May-Aug; moderate rain autumn/winter",
       "wind": "Mistral can be strong; generally sunny",
@@ -7983,7 +7983,7 @@
       "Less tourist infrastructure than mainland ports"
     ],
     "packing_nudges": [
-      "Sunscreen — Sardinia is sunny",
+      "Sunscreen \u2014 Sardinia is sunny",
       "Beach gear for Poetto",
       "Comfortable walking shoes for Castello",
       "Cash for traditional restaurants"
@@ -8091,7 +8091,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "60-88°F tropical",
+      "temp_range": "60-88\u00b0F tropical",
       "humidity": "High summer; moderate dry season",
       "rain": "Very wet Nov-Apr (monsoonal); dry May-Oct",
       "wind": "Trade winds; occasional cyclone threat",
@@ -8139,7 +8139,7 @@
       "Stinger suits are required for ocean swimming Nov-May",
       "Great Barrier Reef visibility is best in dry season",
       "Daintree Rainforest is accessible year-round but less muddy in dry season",
-      "Crocodiles are a real presence — never swim in rivers or estuaries"
+      "Crocodiles are a real presence \u2014 never swim in rivers or estuaries"
     ],
     "packing_nudges": [
       "Stinger suit or rashguard for reef swimming",
@@ -8150,7 +8150,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Nov – Apr (Australian/South Pacific cyclone season)",
+      "hurricane_season": "Nov \u2013 Apr (Australian/South Pacific cyclone season)",
       "peak_risk_months": [
         "Jan",
         "Feb",
@@ -8256,9 +8256,9 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "57-81°F — desert coast with persistent overcast",
-      "humidity": "High year-round — garúa fog",
-      "rain": "Almost none — one of driest capitals",
+      "temp_range": "57-81\u00b0F \u2014 desert coast with persistent overcast",
+      "humidity": "High year-round \u2014 gar\u00faa fog",
+      "rain": "Almost none \u2014 one of driest capitals",
       "wind": "Moderate coastal winds",
       "daylight": "11-13 hours seasonal"
     },
@@ -8290,14 +8290,14 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "Lima is the gastronomic capital of South America — budget for fine dining",
-      "Garúa (coastal fog) blankets the coast May-Nov — gray and cool",
+      "Lima is the gastronomic capital of South America \u2014 budget for fine dining",
+      "Gar\u00faa (coastal fog) blankets the coast May-Nov \u2014 gray and cool",
       "When the sun does come out (Dec-Mar), it's glorious",
       "Miraflores and Barranco are the main tourist neighborhoods",
-      "The port (Callao) is rough — take organized transport to Lima"
+      "The port (Callao) is rough \u2014 take organized transport to Lima"
     ],
     "packing_nudges": [
-      "Layers — the garúa makes it feel colder than temperature suggests",
+      "Layers \u2014 the gar\u00faa makes it feel colder than temperature suggests",
       "Light jacket for fog season",
       "Comfortable walking shoes",
       "Sunscreen for sunny season",
@@ -8305,7 +8305,7 @@
     ],
     "hazards": {
       "hurricane_zone": false,
-      "note": "Garúa (coastal fog) blankets the coast May-Nov — gray and cool. The port (Callao) is rough — take organized transport to Lima."
+      "note": "Gar\u00faa (coastal fog) blankets the coast May-Nov \u2014 gray and cool. The port (Callao) is rough \u2014 take organized transport to Lima."
     },
     "cruise_seasons": {
       "high": [
@@ -8406,7 +8406,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "39-82°F — French Riviera glamour",
+      "temp_range": "39-82\u00b0F \u2014 French Riviera glamour",
       "humidity": "Moderate (54-70%)",
       "rain": "Dry summers; wetter autumn",
       "wind": "Occasional Mistral; generally calm",
@@ -8447,8 +8447,8 @@
       "Film Festival (May) makes the city inaccessible",
       "La Croisette promenade is beautiful for walking",
       "Old town (Le Suquet) has best views and authentic restaurants",
-      "Lérins Islands ferry is a peaceful escape",
-      "Beach clubs charge for sun loungers — public beaches between them"
+      "L\u00e9rins Islands ferry is a peaceful escape",
+      "Beach clubs charge for sun loungers \u2014 public beaches between them"
     ],
     "packing_nudges": [
       "Smart casual for restaurants",
@@ -8559,7 +8559,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "22-80°F — New England coastal",
+      "temp_range": "22-80\u00b0F \u2014 New England coastal",
       "humidity": "Moderate; fog common",
       "rain": "Distributed; drier summer",
       "wind": "Strong sea breezes common",
@@ -8606,11 +8606,11 @@
       "Cape Cod National Seashore has some of the best beaches on the East Coast",
       "Whale watching from Provincetown is excellent May-Oct",
       "The Cape Cod Rail Trail is a scenic 22-mile bike path",
-      "Great white sharks patrol outer Cape beaches Jul-Oct — caution",
+      "Great white sharks patrol outer Cape beaches Jul-Oct \u2014 caution",
       "Provincetown at the tip is a vibrant arts community"
     ],
     "packing_nudges": [
-      "Layers — sea breezes cool things quickly",
+      "Layers \u2014 sea breezes cool things quickly",
       "Light jacket even in summer",
       "Comfortable walking/biking shoes",
       "Sunscreen",
@@ -8618,7 +8618,7 @@
     ],
     "hazards": {
       "hurricane_zone": false,
-      "note": "Great white sharks patrol outer Cape beaches Jul-Oct — caution."
+      "note": "Great white sharks patrol outer Cape beaches Jul-Oct \u2014 caution."
     },
     "cruise_seasons": {
       "high": [
@@ -8719,8 +8719,8 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "30-52°F — windswept extremity of South America",
-      "humidity": "Very high — maritime climate",
+      "temp_range": "30-52\u00b0F \u2014 windswept extremity of South America",
+      "humidity": "Very high \u2014 maritime climate",
       "rain": "Frequent year-round; rain, sleet, or snow",
       "wind": "Among the strongest sustained winds on Earth",
       "daylight": "7-17+ hours (seasonal)"
@@ -8751,13 +8751,13 @@
     ],
     "catches_off_guard": [
       "Rounding Cape Horn is one of maritime history's great achievements",
-      "Landing is possible only on rare calm days — most visitors view from ship",
+      "Landing is possible only on rare calm days \u2014 most visitors view from ship",
       "The Cape Horn monument and lighthouse are dramatic",
-      "Drake Passage seas begin south of here — conditions can be extreme",
+      "Drake Passage seas begin south of here \u2014 conditions can be extreme",
       "Albatross and petrels are commonly spotted"
     ],
     "packing_nudges": [
-      "Full waterproof gear — heavy duty",
+      "Full waterproof gear \u2014 heavy duty",
       "Warm waterproof layers",
       "Strong windproof jacket",
       "Warm hat, gloves, neck gaiter",
@@ -8865,7 +8865,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "26-86°F — four seasons, NYC metro",
+      "temp_range": "26-86\u00b0F \u2014 four seasons, NYC metro",
       "humidity": "Moderate; muggy summers",
       "rain": "Distributed year-round",
       "wind": "Can be strong near the waterfront",
@@ -8902,7 +8902,7 @@
       "Cape Liberty offers direct views of the Statue of Liberty and Manhattan skyline",
       "NYC is accessible by car/transit but allow 1+ hour each way",
       "Liberty State Park surrounds the terminal",
-      "The terminal is in Bayonne, NJ — not Manhattan",
+      "The terminal is in Bayonne, NJ \u2014 not Manhattan",
       "Embarkation day parking is available at the terminal"
     ],
     "packing_nudges": [
@@ -8914,7 +8914,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Sep",
         "Oct"
@@ -9019,7 +9019,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "43-79°F — Mediterranean climate (Southern Hemisphere)",
+      "temp_range": "43-79\u00b0F \u2014 Mediterranean climate (Southern Hemisphere)",
       "humidity": "Moderate; drier summer",
       "rain": "Wet winters (Jun-Aug); dry summers (Dec-Feb)",
       "wind": "Strong 'Cape Doctor' southeaster in summer",
@@ -9071,10 +9071,10 @@
       "The Cape Doctor wind (summer southeaster) can be very strong",
       "Cape of Good Hope is exposed and much colder than the city",
       "Penguin colony at Boulders Beach is a short drive away",
-      "Southern Hemisphere seasons are reversed — Dec-Feb is summer"
+      "Southern Hemisphere seasons are reversed \u2014 Dec-Feb is summer"
     ],
     "packing_nudges": [
-      "Layers — temperature swings 20°F in a day",
+      "Layers \u2014 temperature swings 20\u00b0F in a day",
       "Windproof jacket essential",
       "Sunscreen for strong UV",
       "Comfortable walking shoes",
@@ -9182,7 +9182,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "44-83°F — island microclimate",
+      "temp_range": "44-83\u00b0F \u2014 island microclimate",
       "humidity": "Moderate (52-74%)",
       "rain": "Dry summers; wetter winters",
       "wind": "Exposed to winds from all directions",
@@ -9221,14 +9221,14 @@
       "Aug"
     ],
     "catches_off_guard": [
-      "Blue Grotto often closed due to sea conditions — no guarantee",
+      "Blue Grotto often closed due to sea conditions \u2014 no guarantee",
       "Anacapri (upper town) is quieter and more authentic",
       "Chairlift to Monte Solaro offers best views",
-      "August is absolutely packed — avoid if possible",
+      "August is absolutely packed \u2014 avoid if possible",
       "Funicular from port to town runs frequently but queues form"
     ],
     "packing_nudges": [
-      "Comfortable walking shoes — steep paths",
+      "Comfortable walking shoes \u2014 steep paths",
       "Sunscreen",
       "Cash for Blue Grotto entrance",
       "Light jacket for Monte Solaro summit"
@@ -9336,7 +9336,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "77-89°F year-round — consistently hot",
+      "temp_range": "77-89\u00b0F year-round \u2014 consistently hot",
       "humidity": "High (77-83%)",
       "rain": "Drier Dec-Apr; wetter May-Nov",
       "wind": "Trades Dec-Mar",
@@ -9381,20 +9381,20 @@
     ],
     "catches_off_guard": [
       "Walled City is UNESCO World Heritage",
-      "Heat and humidity relentless — hydrate constantly",
+      "Heat and humidity relentless \u2014 hydrate constantly",
       "Vendors very persistent",
       "Rosario Islands day trip worth it",
       "Extraordinary colonial history"
     ],
     "packing_nudges": [
       "Light breathable clothing",
-      "Water bottle — essential",
+      "Water bottle \u2014 essential",
       "Walking shoes for cobblestones",
       "Sunscreen and hat"
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Oct",
         "Nov"
@@ -9500,7 +9500,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "43-85°F — warm Mediterranean",
+      "temp_range": "43-85\u00b0F \u2014 warm Mediterranean",
       "humidity": "Low to moderate",
       "rain": "Very dry summers; light winter rain",
       "wind": "Light; sheltered harbor",
@@ -9535,7 +9535,7 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "The Roman Theatre is one of Spain's best-preserved — discovered in 1988",
+      "The Roman Theatre is one of Spain's best-preserved \u2014 discovered in 1988",
       "The naval base gives Cartagena a military heritage",
       "Modernist architecture rivals Barcelona's on a smaller scale",
       "The city is very walkable from the cruise port",
@@ -9650,7 +9650,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "46-83°F — Atlantic-moderated",
+      "temp_range": "46-83\u00b0F \u2014 Atlantic-moderated",
       "humidity": "Moderate to high; oceanic influence",
       "rain": "Wet Nov-Mar; dry summers",
       "wind": "Atlantic breezes; can be cool",
@@ -9684,9 +9684,9 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "Hassan II Mosque is spectacular — one of the largest in the world",
+      "Hassan II Mosque is spectacular \u2014 one of the largest in the world",
       "Casablanca is Morocco's economic capital, not the tourist capital",
-      "Rick's Café (inspired by the movie) exists but is a tourist trap",
+      "Rick's Caf\u00e9 (inspired by the movie) exists but is a tourist trap",
       "The old medina is interesting but not as grand as Fez or Marrakech",
       "Day trips to Rabat (1 hour) offer the royal palace and kasbah"
     ],
@@ -9799,7 +9799,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "39-87°F — hot summers, mild winters",
+      "temp_range": "39-87\u00b0F \u2014 hot summers, mild winters",
       "humidity": "Low to moderate (40-70%)",
       "rain": "Very dry Jun-Aug; rainy autumn",
       "wind": "Sirocco from Africa brings heat waves",
@@ -9844,15 +9844,15 @@
       "Aug"
     ],
     "catches_off_guard": [
-      "Mount Etna is active — eruptions happen regularly",
-      "Sirocco wind from Africa can push temps above 100°F",
+      "Mount Etna is active \u2014 eruptions happen regularly",
+      "Sirocco wind from Africa can push temps above 100\u00b0F",
       "Fish market (La Pescheria) is sensory overload in best way",
       "Baroque architecture is UNESCO-listed",
       "Arancini (rice balls) are Catania's signature food"
     ],
     "packing_nudges": [
       "Comfortable shoes for lava terrain on Etna",
-      "Warm layer for Etna summit — much cooler up top",
+      "Warm layer for Etna summit \u2014 much cooler up top",
       "Sunscreen",
       "Cash for market and street food"
     ],
@@ -9959,7 +9959,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "42-86°F — Captain Corelli's island",
+      "temp_range": "42-86\u00b0F \u2014 Captain Corelli's island",
       "humidity": "Moderate (43-73%)",
       "rain": "Dry Jun-Aug; wet winters",
       "wind": "Moderate",
@@ -9994,9 +9994,9 @@
     "catches_off_guard": [
       "Myrtos Beach regularly voted Greece's most beautiful",
       "Melissani Cave underground lake is magical",
-      "Devastated by 1953 earthquake — rebuilt in concrete",
+      "Devastated by 1953 earthquake \u2014 rebuilt in concrete",
       "Robola wine is excellent local variety",
-      "Less developed than Corfu — more authentic"
+      "Less developed than Corfu \u2014 more authentic"
     ],
     "packing_nudges": [
       "Water shoes for rocky beaches",
@@ -10107,7 +10107,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "38-90°F — subtropical four seasons",
+      "temp_range": "38-90\u00b0F \u2014 subtropical four seasons",
       "humidity": "Moderate to high; very humid summers",
       "rain": "Summer afternoon thunderstorms; drier fall",
       "wind": "Light; sea breezes",
@@ -10146,7 +10146,7 @@
     "avoid_months": [],
     "catches_off_guard": [
       "Charleston's historic district is one of America's best-preserved",
-      "Summer heat and humidity are oppressive — pace yourself",
+      "Summer heat and humidity are oppressive \u2014 pace yourself",
       "The carriage tours are a classic way to see the city",
       "Lowcountry cuisine (shrimp & grits, she-crab soup) is a must",
       "Rainbow Row and the Battery are iconic photo spots"
@@ -10160,7 +10160,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Sep",
         "Oct"
@@ -10265,10 +10265,10 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "13-76°F — PEI maritime",
+      "temp_range": "13-76\u00b0F \u2014 PEI maritime",
       "humidity": "Moderate; ocean-moderated",
       "rain": "Distributed; snow winters",
-      "wind": "Can be brisk — island exposed",
+      "wind": "Can be brisk \u2014 island exposed",
       "daylight": "8.5-15.5 hours seasonal"
     },
     "best_months_for": {
@@ -10306,11 +10306,11 @@
       "Mar"
     ],
     "catches_off_guard": [
-      "Anne of Green Gables tourism is huge — Cavendish is 40 min drive",
-      "PEI is famous for lobster suppers — an essential experience",
+      "Anne of Green Gables tourism is huge \u2014 Cavendish is 40 min drive",
+      "PEI is famous for lobster suppers \u2014 an essential experience",
       "Red sand beaches are unique and beautiful",
       "Confederation Bridge is an engineering marvel (13 km long)",
-      "The city is walkable and charming — Canada's birthplace"
+      "The city is walkable and charming \u2014 Canada's birthplace"
     ],
     "packing_nudges": [
       "Layers for maritime weather",
@@ -10421,7 +10421,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "38-66°F — mild Normandy coast",
+      "temp_range": "38-66\u00b0F \u2014 mild Normandy coast",
       "humidity": "High year-round; maritime",
       "rain": "Frequent; slightly drier May-Jul",
       "wind": "Can be strong; English Channel exposure",
@@ -10457,8 +10457,8 @@
     "avoid_months": [],
     "catches_off_guard": [
       "Cherbourg is the gateway to D-Day beaches and Normandy",
-      "La Cité de la Mer (maritime museum with a submarine) is excellent",
-      "The harbor was vital in WWII — history is everywhere",
+      "La Cit\u00e9 de la Mer (maritime museum with a submarine) is excellent",
+      "The harbor was vital in WWII \u2014 history is everywhere",
       "Bayeux Tapestry is a day trip (1 hour)",
       "The English Channel can make the port very windy"
     ],
@@ -10467,7 +10467,7 @@
       "Rain jacket essential",
       "Comfortable walking shoes",
       "Warm hat for windy port",
-      "Layers — weather changes quickly"
+      "Layers \u2014 weather changes quickly"
     ],
     "hazards": {
       "hurricane_zone": false,
@@ -10572,8 +10572,8 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "31-57°F — temperate rainforest fjords",
-      "humidity": "Very high — one of wettest places on Earth",
+      "temp_range": "31-57\u00b0F \u2014 temperate rainforest fjords",
+      "humidity": "Very high \u2014 one of wettest places on Earth",
       "rain": "Extremely wet year-round (200+ inches in places)",
       "wind": "Strong; funneled through fjord channels",
       "daylight": "7.5-17 hours (seasonal)"
@@ -10607,10 +10607,10 @@
       "Aug"
     ],
     "catches_off_guard": [
-      "The Chilean Fjords are often compared to Norway — equally spectacular",
+      "The Chilean Fjords are often compared to Norway \u2014 equally spectacular",
       "Glaciers calve directly into the channels in places",
       "Waterfalls are everywhere, especially after rain (which is always)",
-      "This is scenic cruising — you stay on the ship",
+      "This is scenic cruising \u2014 you stay on the ship",
       "The Valdivian temperate rainforest is one of the few in the Southern Hemisphere"
     ],
     "packing_nudges": [
@@ -10723,7 +10723,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "32-72°F temperate with Canterbury plains influence",
+      "temp_range": "32-72\u00b0F temperate with Canterbury plains influence",
       "humidity": "Moderate; variable",
       "rain": "Distributed year-round; lighter than west coast",
       "wind": "Canterbury nor'wester can be very strong and hot",
@@ -10756,14 +10756,14 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "Christchurch is still rebuilding from the 2011 earthquake — gap sites remain",
+      "Christchurch is still rebuilding from the 2011 earthquake \u2014 gap sites remain",
       "The Canterbury nor'wester wind brings sudden hot dry conditions",
-      "Lyttelton is the actual port — charming village with cafes",
+      "Lyttelton is the actual port \u2014 charming village with cafes",
       "Antarctic Centre near the airport is a unique attraction",
       "Banks Peninsula has beautiful bays accessible by car"
     ],
     "packing_nudges": [
-      "Layers — temperature swings are common",
+      "Layers \u2014 temperature swings are common",
       "Waterproof jacket",
       "Sunscreen SPF 50+",
       "Comfortable walking shoes",
@@ -10871,8 +10871,8 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "54-84°F; hot dry summers, mild wet winters",
-      "humidity": "Moderate (62-74%) — coastal Mediterranean climate",
+      "temp_range": "54-84\u00b0F; hot dry summers, mild wet winters",
+      "humidity": "Moderate (62-74%) \u2014 coastal Mediterranean climate",
       "rain": "Wettest Nov-Feb; summers very dry",
       "wind": "Coastal breezes; can be strong in spring",
       "daylight": "9-15 hours; maximize Rome sightseeing with long summer days"
@@ -10916,11 +10916,11 @@
       "Aug"
     ],
     "catches_off_guard": [
-      "Rome is 90 minutes away by train/bus — plan excursion time carefully",
-      "July-August heat in Rome is brutal for outdoor sightseeing (95°F+)",
+      "Rome is 90 minutes away by train/bus \u2014 plan excursion time carefully",
+      "July-August heat in Rome is brutal for outdoor sightseeing (95\u00b0F+)",
       "Lines at Colosseum and Vatican are hours long without skip-the-line tickets",
       "Many restaurants in Rome close in August",
-      "Port town itself has limited appeal — it's a gateway to Rome",
+      "Port town itself has limited appeal \u2014 it's a gateway to Rome",
       "Traffic in Rome can add significant time to return journey"
     ],
     "packing_nudges": [
@@ -11034,7 +11034,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "74-91°F year-round tropical",
+      "temp_range": "74-91\u00b0F year-round tropical",
       "humidity": "Extreme during monsoon (Jun-Sep)",
       "rain": "Southwest monsoon Jun-Sep brings torrential rain; dry Dec-Mar",
       "wind": "Strong monsoon winds Jun-Sep",
@@ -11077,7 +11077,7 @@
       "Aug"
     ],
     "catches_off_guard": [
-      "The monsoon (Jun-Sep) is genuinely extreme — expect nonstop rain",
+      "The monsoon (Jun-Sep) is genuinely extreme \u2014 expect nonstop rain",
       "Backwaters are magical in dry season but flooded during monsoon",
       "Ayurvedic treatments are a popular monsoon-season activity",
       "Fort Kochi is walkable but has no shade",
@@ -11092,7 +11092,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Nov – Apr (Indian Ocean cyclone season)",
+      "hurricane_season": "Nov \u2013 Apr (Indian Ocean cyclone season)",
       "peak_risk_months": [
         "Jan",
         "Feb",
@@ -11198,7 +11198,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "65-90°F year-round",
+      "temp_range": "65-90\u00b0F year-round",
       "humidity": "Moderate (70-79%)",
       "rain": "Brief showers; wetter Jun-Oct",
       "wind": "Easterly trades",
@@ -11238,9 +11238,9 @@
     "catches_off_guard": [
       "Royal Caribbean private island",
       "Thrill Waterpark is signature attraction",
-      "Beach chairs go fast — arrive early",
+      "Beach chairs go fast \u2014 arrive early",
       "Floating cabanas book weeks ahead",
-      "SeaPass charges — no cash needed"
+      "SeaPass charges \u2014 no cash needed"
     ],
     "packing_nudges": [
       "Reef-safe sunscreen",
@@ -11250,7 +11250,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Sep",
         "Oct"
@@ -11275,6 +11275,159 @@
         "Aug",
         "Sep",
         "Oct"
+      ]
+    }
+  },
+  "college-fjord": {
+    "tier": 1,
+    "timezone": "America/Anchorage",
+    "_source": "Temps/rain days: Valdez NOAA 1991-2020 (Wikipedia/NOAA climate table, session 2026-09-03). Humidity: Whittier entry already in this file (nearest Prince William Sound station). College Fjord has no town weather station.",
+    "monthly_averages": {
+      "jan": {
+        "high_f": 29,
+        "low_f": 19,
+        "rain_days": 16,
+        "humidity": 73
+      },
+      "feb": {
+        "high_f": 32,
+        "low_f": 21,
+        "rain_days": 15,
+        "humidity": 71
+      },
+      "mar": {
+        "high_f": 37,
+        "low_f": 23,
+        "rain_days": 14,
+        "humidity": 69
+      },
+      "apr": {
+        "high_f": 46,
+        "low_f": 32,
+        "rain_days": 14,
+        "humidity": 67
+      },
+      "may": {
+        "high_f": 56,
+        "low_f": 40,
+        "rain_days": 15,
+        "humidity": 68
+      },
+      "jun": {
+        "high_f": 62,
+        "low_f": 46,
+        "rain_days": 14,
+        "humidity": 72
+      },
+      "jul": {
+        "high_f": 64,
+        "low_f": 49,
+        "rain_days": 18,
+        "humidity": 77
+      },
+      "aug": {
+        "high_f": 62,
+        "low_f": 47,
+        "rain_days": 18,
+        "humidity": 79
+      },
+      "sep": {
+        "high_f": 55,
+        "low_f": 42,
+        "rain_days": 21,
+        "humidity": 80
+      },
+      "oct": {
+        "high_f": 45,
+        "low_f": 34,
+        "rain_days": 19,
+        "humidity": 79
+      },
+      "nov": {
+        "high_f": 34,
+        "low_f": 25,
+        "rain_days": 16,
+        "humidity": 76
+      },
+      "dec": {
+        "high_f": 31,
+        "low_f": 22,
+        "rain_days": 17,
+        "humidity": 75
+      }
+    },
+    "at_a_glance": {
+      "temp_range": "19-64\u00b0F \u2014 glacier water, cooler than town",
+      "humidity": "High; PWS marine air",
+      "rain": "Wet year-round; fall heaviest",
+      "wind": "Fjords can funnel; glacier days run colder than town",
+      "daylight": "6-19 hours (seasonal)"
+    },
+    "best_months_for": {
+      "glacier_viewing": [
+        "May",
+        "Jun",
+        "Jul",
+        "Aug",
+        "Sep"
+      ],
+      "wildlife": [
+        "Jun",
+        "Jul",
+        "Aug"
+      ],
+      "photography": [
+        "May",
+        "Jun",
+        "Jul",
+        "Aug"
+      ],
+      "low_crowds": [
+        "May",
+        "Sep"
+      ]
+    },
+    "avoid_months": [
+      "Nov",
+      "Dec",
+      "Jan",
+      "Feb",
+      "Mar"
+    ],
+    "catches_off_guard": [
+      "This is a scenic cruising day, not a dock \u2014 you stay on the ship",
+      "Air over the ice is colder than the Valdez forecast",
+      "Harvard and Yale glaciers are the usual named walls",
+      "Wildlife is at the waterline: sea otters, harbor seals on ice",
+      "Cloud can close the fjord; the ship still transits"
+    ],
+    "packing_nudges": [
+      "Warm layer for the outer deck even in July",
+      "Gloves for the rail",
+      "Binoculars",
+      "A hat that stays on in fjord wind"
+    ],
+    "hazards": {
+      "hurricane_zone": false
+    },
+    "cruise_seasons": {
+      "high": [
+        "Jun",
+        "Jul",
+        "Aug"
+      ],
+      "transitional": [
+        "May",
+        "Sep"
+      ],
+      "low": [
+        "Oct",
+        "Nov",
+        "Dec",
+        "Jan",
+        "Feb",
+        "Mar",
+        "Apr"
       ]
     }
   },
@@ -11356,7 +11509,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "72-90°F year-round tropical",
+      "temp_range": "72-90\u00b0F year-round tropical",
       "humidity": "High year-round; two monsoon peaks",
       "rain": "Southwest monsoon May-Sep; northeast monsoon Oct-Jan",
       "wind": "Monsoon winds create seasonal rough seas",
@@ -11397,7 +11550,7 @@
     "catches_off_guard": [
       "Sri Lanka has two monsoon seasons affecting different coasts",
       "West coast beaches are best Dec-Mar; east coast Apr-Sep",
-      "Colombo is hot year-round — pace yourself",
+      "Colombo is hot year-round \u2014 pace yourself",
       "Tuk-tuk rides are the fastest way around the city",
       "Full moon (Poya) days close liquor shops and many businesses"
     ],
@@ -11410,7 +11563,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Nov – Apr (Indian Ocean cyclone season)",
+      "hurricane_season": "Nov \u2013 Apr (Indian Ocean cyclone season)",
       "peak_risk_months": [
         "Jan",
         "Feb",
@@ -11516,7 +11669,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "74-87°F year-round",
+      "temp_range": "74-87\u00b0F year-round",
       "humidity": "Very high (79-87%)",
       "rain": "Wet most of year; drier Jan-Apr",
       "wind": "Light; sheltered harbor",
@@ -11551,7 +11704,7 @@
     ],
     "catches_off_guard": [
       "Gateway to Panama Canal",
-      "Colón city has security concerns outside cruise/canal areas",
+      "Col\u00f3n city has security concerns outside cruise/canal areas",
       "Portobelo ruins worth excursion",
       "San Lorenzo fortress hidden gem",
       "Extremely humid year-round"
@@ -11560,11 +11713,11 @@
       "Light breathable clothing",
       "Rain jacket",
       "Bug repellent",
-      "Cash — USD accepted"
+      "Cash \u2014 USD accepted"
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Sep",
         "Oct"
@@ -11670,8 +11823,8 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "37-72°F; cool maritime climate, cold winters",
-      "humidity": "High (67-86%) — damp northern European climate",
+      "temp_range": "37-72\u00b0F; cool maritime climate, cold winters",
+      "humidity": "High (67-86%) \u2014 damp northern European climate",
       "rain": "Frequent drizzle year-round; wettest Nov-Dec",
       "wind": "Coastal winds make it feel colder than actual temperature",
       "daylight": "7-17 hours; bright summer nights, dark winter afternoons"
@@ -11717,12 +11870,12 @@
       "Feb"
     ],
     "catches_off_guard": [
-      "July is 'warm' but only 72°F — bring layers even in summer",
-      "Biking culture is intense — watch for speeding cyclists",
+      "July is 'warm' but only 72\u00b0F \u2014 bring layers even in summer",
+      "Biking culture is intense \u2014 watch for speeding cyclists",
       "One of the most expensive cities in the world",
-      "Rain can happen any day year-round — always bring waterproof",
+      "Rain can happen any day year-round \u2014 always bring waterproof",
       "Many museums closed Mondays",
-      "Danes are reserved — don't expect chatty locals"
+      "Danes are reserved \u2014 don't expect chatty locals"
     ],
     "packing_nudges": [
       "Waterproof jacket (essential year-round)",
@@ -11835,7 +11988,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "40-87°F — greenest Greek island",
+      "temp_range": "40-87\u00b0F \u2014 greenest Greek island",
       "humidity": "Moderate (47-74%)",
       "rain": "Wettest Greek island; dry Jun-Aug",
       "wind": "Moderate; sheltered east coast",
@@ -11874,14 +12027,14 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "Greenest Greek island — looks more like Italy",
+      "Greenest Greek island \u2014 looks more like Italy",
       "Venetian, French, British influences in architecture",
       "Old Town is UNESCO World Heritage",
       "Paleokastritsa on west coast is stunning",
-      "Cricket is played here — British legacy"
+      "Cricket is played here \u2014 British legacy"
     ],
     "packing_nudges": [
-      "Light rain jacket — wetter than other Greek islands",
+      "Light rain jacket \u2014 wetter than other Greek islands",
       "Comfortable shoes for Old Town",
       "Sunscreen",
       "Cash for tavernas"
@@ -11989,7 +12142,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "72-93°F — hot Pacific coast",
+      "temp_range": "72-93\u00b0F \u2014 hot Pacific coast",
       "humidity": "Moderate to high (65-82%)",
       "rain": "Bone-dry Nov-Apr; wet May-Oct",
       "wind": "Strong Pacific breezes",
@@ -12029,21 +12182,21 @@
       "Oct"
     ],
     "catches_off_guard": [
-      "Pacific coast — different from Caribbean Nicaragua",
+      "Pacific coast \u2014 different from Caribbean Nicaragua",
       "Virtually no rain Nov-Apr",
-      "León day trip popular",
+      "Le\u00f3n day trip popular",
       "Very hot in dry season",
       "Limited tourist infrastructure"
     ],
     "packing_nudges": [
       "High-SPF sunscreen",
-      "Water bottle — essential",
+      "Water bottle \u2014 essential",
       "Light breathable clothing",
-      "Cash in córdobas"
+      "Cash in c\u00f3rdobas"
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "May 15 – Nov 30 (East Pacific)",
+      "hurricane_season": "May 15 \u2013 Nov 30 (East Pacific)",
       "peak_risk_months": [
         "Aug",
         "Sep",
@@ -12150,7 +12303,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "37-65°F — mild Irish maritime",
+      "temp_range": "37-65\u00b0F \u2014 mild Irish maritime",
       "humidity": "High year-round",
       "rain": "Frequent year-round; slightly drier Apr-Jun",
       "wind": "Can be strong; Atlantic exposure",
@@ -12191,10 +12344,10 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "Cobh (the port) was the Titanic's last port of call — heritage center tells the story",
+      "Cobh (the port) was the Titanic's last port of call \u2014 heritage center tells the story",
       "Blarney Castle (kiss the stone) is 30 min from Cork city",
       "Cork's English Market is one of Europe's best food markets",
-      "The city has a vibrant pub culture — live music most nights",
+      "The city has a vibrant pub culture \u2014 live music most nights",
       "Cobh's colorful waterfront houses are instantly recognizable"
     ],
     "packing_nudges": [
@@ -12306,7 +12459,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "69-91°F year-round",
+      "temp_range": "69-91\u00b0F year-round",
       "humidity": "Moderate to high (72-80%)",
       "rain": "Dry Dec-Apr; wet Jun-Oct",
       "wind": "Trades; gusty winter",
@@ -12345,7 +12498,7 @@
       "Oct"
     ],
     "catches_off_guard": [
-      "Very isolated — little beyond port complex",
+      "Very isolated \u2014 little beyond port complex",
       "Chacchoben ruins is a long bus ride",
       "Beach is man-made within port",
       "Mosquitoes fierce in jungle",
@@ -12359,7 +12512,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Sep",
         "Oct"
@@ -12465,8 +12618,8 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "70-90°F year-round",
-      "humidity": "High (75-82%) — tropical island climate",
+      "temp_range": "70-90\u00b0F year-round",
+      "humidity": "High (75-82%) \u2014 tropical island climate",
       "rain": "Brief afternoon showers common; heaviest Jun-Oct",
       "wind": "Trade winds provide relief; strongest Dec-Apr",
       "daylight": "11-13 hours depending on season"
@@ -12508,22 +12661,22 @@
       "Oct"
     ],
     "catches_off_guard": [
-      "Afternoon squalls can appear suddenly — rain is brief but intense",
-      "Humidity makes 85°F feel much hotter; pace yourself",
+      "Afternoon squalls can appear suddenly \u2014 rain is brief but intense",
+      "Humidity makes 85\u00b0F feel much hotter; pace yourself",
       "Trade winds can create chop on the east side for snorkeling",
-      "Sun is intense even on cloudy days — reef-safe sunscreen essential",
+      "Sun is intense even on cloudy days \u2014 reef-safe sunscreen essential",
       "September has highest hurricane risk; ships may divert"
     ],
     "packing_nudges": [
       "Reef-safe sunscreen (required by law for snorkeling)",
       "Light rain jacket or poncho for afternoon showers",
       "Water shoes for rocky beach entries",
-      "Breathable clothing — cotton wilts in humidity",
+      "Breathable clothing \u2014 cotton wilts in humidity",
       "Insect repellent for ruins and jungle areas"
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Sep",
         "Oct"
@@ -12629,8 +12782,8 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "75-90°F year-round",
-      "humidity": "Low to moderate (64-70%) — dry island",
+      "temp_range": "75-90\u00b0F year-round",
+      "humidity": "Low to moderate (64-70%) \u2014 dry island",
       "rain": "Very little; brief showers Oct-Jan",
       "wind": "Constant trades",
       "daylight": "11.5-12.5 hours"
@@ -12676,11 +12829,11 @@
       "Dry climate unlike most Caribbean",
       "Willemstad is UNESCO World Heritage",
       "Beaches are small coves not long stretches",
-      "Queen Emma Bridge opens for ships — pedestrian delays",
+      "Queen Emma Bridge opens for ships \u2014 pedestrian delays",
       "Wind is constant"
     ],
     "packing_nudges": [
-      "Sunscreen — breeze masks burns",
+      "Sunscreen \u2014 breeze masks burns",
       "Water shoes for coral beaches",
       "Walking shoes for Willemstad",
       "Windbreaker for evening"
@@ -12788,7 +12941,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "66-92°F tropical range",
+      "temp_range": "66-92\u00b0F tropical range",
       "humidity": "High year-round; wettest Sep-Dec",
       "rain": "Rainy season Sep-Dec; driest Feb-May",
       "wind": "Monsoon shifts create distinct wet/dry seasons",
@@ -12824,7 +12977,7 @@
       "Nov"
     ],
     "catches_off_guard": [
-      "The rainy season (Sep-Dec) brings flooding — Hoi An can be underwater",
+      "The rainy season (Sep-Dec) brings flooding \u2014 Hoi An can be underwater",
       "Dry season (Feb-May) is best but temperatures soar",
       "Marble Mountains are slippery when wet",
       "Beach conditions vary dramatically by season",
@@ -12839,7 +12992,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "May – Nov (Western Pacific typhoon season)",
+      "hurricane_season": "May \u2013 Nov (Western Pacific typhoon season)",
       "peak_risk_months": [
         "Aug",
         "Sep",
@@ -12945,7 +13098,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "64-88°F tropical coastal",
+      "temp_range": "64-88\u00b0F tropical coastal",
       "humidity": "Low dry season; high wet season",
       "rain": "Wet season Jul-Oct; dry Nov-Jun",
       "wind": "Harmattan (dry desert wind) Dec-Feb",
@@ -12991,10 +13144,10 @@
       "Sep"
     ],
     "catches_off_guard": [
-      "Gorée Island (slave trade history) is deeply moving and a must-visit",
+      "Gor\u00e9e Island (slave trade history) is deeply moving and a must-visit",
       "The Harmattan wind brings hazy, dusty conditions Dec-Feb",
       "Wet season rains can flood streets rapidly",
-      "Dakar is a vibrant music city — catch live performances",
+      "Dakar is a vibrant music city \u2014 catch live performances",
       "French is the primary language; Wolof is widely spoken"
     ],
     "packing_nudges": [
@@ -13107,7 +13260,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "64-93°F tropical with wet/dry extremes",
+      "temp_range": "64-93\u00b0F tropical with wet/dry extremes",
       "humidity": "Extreme wet season; low dry season",
       "rain": "Monsoon wet season Nov-Apr; bone-dry May-Oct",
       "wind": "Monsoon storms can be severe",
@@ -13151,7 +13304,7 @@
       "Box jellyfish and crocodiles make ocean swimming dangerous year-round",
       "Kakadu National Park is best visited May-Sep (many areas flood in wet)",
       "Mindil Beach Markets (May-Oct) are a Darwin highlight",
-      "The dry season is spectacularly pleasant — blue skies, low humidity"
+      "The dry season is spectacularly pleasant \u2014 blue skies, low humidity"
     ],
     "packing_nudges": [
       "Light breathable clothing",
@@ -13162,7 +13315,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Nov – Apr (Australian/South Pacific cyclone season)",
+      "hurricane_season": "Nov \u2013 Apr (Australian/South Pacific cyclone season)",
       "peak_risk_months": [
         "Jan",
         "Feb",
@@ -13268,7 +13421,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "-1 to 66°F — interior Alaska extreme range",
+      "temp_range": "-1 to 66\u00b0F \u2014 interior Alaska extreme range",
       "humidity": "Low to moderate",
       "rain": "Light; wettest Jul-Aug",
       "wind": "Can be strong at elevation",
@@ -13311,10 +13464,10 @@
       "Mar"
     ],
     "catches_off_guard": [
-      "Denali (the mountain) is visible only 30% of summer days — cloud cover is normal",
+      "Denali (the mountain) is visible only 30% of summer days \u2014 cloud cover is normal",
       "The park bus is the only way into the park beyond mile 15",
       "Grizzly bears, moose, caribou, and wolves are regularly spotted",
-      "Summer daylight is nearly continuous — 21 hours at solstice",
+      "Summer daylight is nearly continuous \u2014 21 hours at solstice",
       "The park is a 4-5 hour bus ride from Anchorage"
     ],
     "packing_nudges": [
@@ -13326,7 +13479,7 @@
     ],
     "hazards": {
       "hurricane_zone": false,
-      "note": "Denali (the mountain) is visible only 30% of summer days — cloud cover is normal. Summer daylight is nearly continuous — 21 hours at solstice."
+      "note": "Denali (the mountain) is visible only 30% of summer days \u2014 cloud cover is normal. Summer daylight is nearly continuous \u2014 21 hours at solstice."
     },
     "cruise_seasons": {
       "high": [
@@ -13427,9 +13580,9 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "56-108°F extreme desert range",
+      "temp_range": "56-108\u00b0F extreme desert range",
       "humidity": "Low summer; moderate winter",
-      "rain": "Virtually none — desert climate",
+      "rain": "Virtually none \u2014 desert climate",
       "wind": "Shamal winds can bring dust Mar-Jun",
       "daylight": "10.5-13.5 hours seasonal"
     },
@@ -13471,10 +13624,10 @@
       "Aug"
     ],
     "catches_off_guard": [
-      "Summer heat exceeds 110°F regularly — outdoor activity is dangerous",
+      "Summer heat exceeds 110\u00b0F regularly \u2014 outdoor activity is dangerous",
       "Souq Waqif is partially covered and manageable in warmth",
       "The Museum of Islamic Art is world-class and air-conditioned",
-      "Alcohol is restricted — available only in licensed hotel bars",
+      "Alcohol is restricted \u2014 available only in licensed hotel bars",
       "Shamal dust winds (Mar-Jun) can disrupt plans and visibility"
     ],
     "packing_nudges": [
@@ -13586,8 +13739,8 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "71-88°F year-round",
-      "humidity": "High (72-80%) — very wet island",
+      "temp_range": "71-88\u00b0F year-round",
+      "humidity": "High (72-80%) \u2014 very wet island",
       "rain": "Rain year-round; driest Feb-Apr",
       "wind": "Trades; sheltered leeward",
       "daylight": "11-13 hours"
@@ -13626,19 +13779,19 @@
     "catches_off_guard": [
       "Most mountainous Caribbean island",
       "Boiling Lake hike is 6-8 hours and strenuous",
-      "Very few beaches — this is a nature island",
+      "Very few beaches \u2014 this is a nature island",
       "Roads steep and sometimes unpaved",
       "Rain can appear any time"
     ],
     "packing_nudges": [
-      "Waterproof hiking boots — essential",
+      "Waterproof hiking boots \u2014 essential",
       "Rain jacket year-round",
       "Bug repellent for rainforest",
       "Quick-dry clothing"
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Aug",
         "Sep",
@@ -13745,8 +13898,8 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "31-64°F — remote fjordland",
-      "humidity": "High — one of wettest places in NZ",
+      "temp_range": "31-64\u00b0F \u2014 remote fjordland",
+      "humidity": "High \u2014 one of wettest places in NZ",
       "rain": "Extremely wet year-round (200+ rain days)",
       "wind": "Can be calm in the sound; exposed outside",
       "daylight": "8.5-16 hours (Southern Hemisphere)"
@@ -13782,11 +13935,11 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "One of the wettest places on Earth — rain is nearly guaranteed",
-      "When it rains, temporary waterfalls appear everywhere — spectacular",
+      "One of the wettest places on Earth \u2014 rain is nearly guaranteed",
+      "When it rains, temporary waterfalls appear everywhere \u2014 spectacular",
       "Bottlenose dolphins, fur seals, and penguins inhabit the sound",
       "It's more remote and less visited than Milford Sound",
-      "Silence is the defining feature — often called the Sound of Silence"
+      "Silence is the defining feature \u2014 often called the Sound of Silence"
     ],
     "packing_nudges": [
       "Full waterproof gear essential",
@@ -13897,10 +14050,10 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "35-69°F — English Channel climate",
+      "temp_range": "35-69\u00b0F \u2014 English Channel climate",
       "humidity": "High; maritime influence",
       "rain": "Distributed; slightly drier summer",
-      "wind": "Can be very strong — exposed coast",
+      "wind": "Can be very strong \u2014 exposed coast",
       "daylight": "8-16.5 hours seasonal"
     },
     "best_months_for": {
@@ -13939,10 +14092,10 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "The White Cliffs of Dover are iconic — visible from France on clear days",
+      "The White Cliffs of Dover are iconic \u2014 visible from France on clear days",
       "Dover Castle has 2,000 years of history including WWII tunnels",
-      "Canterbury (30 min) has the famous cathedral — a UNESCO site",
-      "London is 1.5-2 hours by train — a doable but long day trip",
+      "Canterbury (30 min) has the famous cathedral \u2014 a UNESCO site",
+      "London is 1.5-2 hours by train \u2014 a doable but long day trip",
       "The port is primarily an embarkation/disembarkation point"
     ],
     "packing_nudges": [
@@ -14054,7 +14207,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "21-42°F — Southern Ocean crossing",
+      "temp_range": "21-42\u00b0F \u2014 Southern Ocean crossing",
       "humidity": "Very high",
       "rain": "Frequent precipitation; sea spray",
       "wind": "Some of the strongest ocean winds in the world",
@@ -14084,7 +14237,7 @@
     ],
     "catches_off_guard": [
       "The Drake Passage is 600 miles of the world's roughest ocean",
-      "Drake Shake vs. Drake Lake — conditions are unpredictable",
+      "Drake Shake vs. Drake Lake \u2014 conditions are unpredictable",
       "Most crossings take about 2 days each way",
       "Albatross following the ship is a highlight of the crossing",
       "Pack seasickness medication regardless of your usual tolerance"
@@ -14098,7 +14251,7 @@
     ],
     "hazards": {
       "hurricane_zone": false,
-      "note": "The Drake Passage is 600 miles of the world's roughest ocean. Drake Shake vs. Drake Lake — conditions are unpredictable. Pack seasickness medication regardless of your usual tolerance."
+      "note": "The Drake Passage is 600 miles of the world's roughest ocean. Drake Shake vs. Drake Lake \u2014 conditions are unpredictable. Pack seasickness medication regardless of your usual tolerance."
     },
     "cruise_seasons": {
       "high": [
@@ -14199,7 +14352,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "67-84°F year-round tropical",
+      "temp_range": "67-84\u00b0F year-round tropical",
       "humidity": "High; drier Jun-Oct",
       "rain": "Wet season Nov-Apr; dry May-Oct",
       "wind": "Trade winds",
@@ -14240,8 +14393,8 @@
       "Dravuni is home to fewer than 200 people",
       "The island hike to the summit offers 360-degree reef views",
       "Snorkeling directly off the beach is excellent",
-      "Locals welcome visitors warmly — respect their customs",
-      "There are no shops or facilities — bring what you need"
+      "Locals welcome visitors warmly \u2014 respect their customs",
+      "There are no shops or facilities \u2014 bring what you need"
     ],
     "packing_nudges": [
       "Swimwear and cover-up",
@@ -14252,7 +14405,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Nov – Apr (South Pacific cyclone season)",
+      "hurricane_season": "Nov \u2013 Apr (South Pacific cyclone season)",
       "peak_risk_months": [
         "Jan",
         "Feb",
@@ -14358,9 +14511,9 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "57-106°F extreme desert range",
+      "temp_range": "57-106\u00b0F extreme desert range",
       "humidity": "Low inland; higher coastal",
-      "rain": "Almost none — a few days per year",
+      "rain": "Almost none \u2014 a few days per year",
       "wind": "Occasional sandstorms",
       "daylight": "10.5-13.5 hours seasonal"
     },
@@ -14404,10 +14557,10 @@
       "Aug"
     ],
     "catches_off_guard": [
-      "Summer heat is genuinely dangerous — outdoor activities are impossible",
-      "Even the sea reaches 95°F+ in summer",
+      "Summer heat is genuinely dangerous \u2014 outdoor activities are impossible",
+      "Even the sea reaches 95\u00b0F+ in summer",
       "Indoor attractions (malls, aquariums) are essential summer activities",
-      "Ramadan timing changes yearly — some restaurants close daytime",
+      "Ramadan timing changes yearly \u2014 some restaurants close daytime",
       "Dubai Shopping Festival (Jan-Feb) brings deals but crowds"
     ],
     "packing_nudges": [
@@ -14419,7 +14572,7 @@
     ],
     "hazards": {
       "hurricane_zone": false,
-      "note": "Summer heat is genuinely dangerous — outdoor activities are impossible. Even the sea reaches 95°F+ in summer."
+      "note": "Summer heat is genuinely dangerous \u2014 outdoor activities are impossible. Even the sea reaches 95\u00b0F+ in summer."
     },
     "cruise_seasons": {
       "high": [
@@ -14520,7 +14673,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "35-66°F — mild, wet, green",
+      "temp_range": "35-66\u00b0F \u2014 mild, wet, green",
       "humidity": "High (71-84%)",
       "rain": "Wet year-round; slightly drier spring",
       "wind": "Atlantic; can be gusty",
@@ -14553,13 +14706,13 @@
     "avoid_months": [],
     "catches_off_guard": [
       "Four seasons in one day is genuinely true here",
-      "Temple Bar area is touristy and expensive — locals go elsewhere",
+      "Temple Bar area is touristy and expensive \u2014 locals go elsewhere",
       "Guinness Storehouse is popular but Gravity Bar views justify it",
       "DART coastal train to Howth is excellent half-day trip",
       "Literary pub crawl captures Dublin's soul"
     ],
     "packing_nudges": [
-      "Waterproof jacket — essential",
+      "Waterproof jacket \u2014 essential",
       "Layers for changeable weather",
       "Comfortable walking shoes",
       "Cash for some pubs"
@@ -14667,8 +14820,8 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "52-84°F; hot dry summers, mild wet winters",
-      "humidity": "Moderate (58-68%) — Mediterranean coastal climate",
+      "temp_range": "52-84\u00b0F; hot dry summers, mild wet winters",
+      "humidity": "Moderate (58-68%) \u2014 Mediterranean coastal climate",
       "rain": "Wettest Oct-Feb; dry summers Jul-Aug",
       "wind": "Bura winds in winter can be strong and cold",
       "daylight": "9-15 hours; long summer days ideal for wall walks"
@@ -14712,17 +14865,17 @@
       "Aug"
     ],
     "catches_off_guard": [
-      "Overtourism is severe — Old Town can have 10,000+ cruise passengers per day in summer",
-      "City walls have no shade and are brutal in midday heat (90°F+)",
-      "Tender port when busy — can have long waits for tenders",
+      "Overtourism is severe \u2014 Old Town can have 10,000+ cruise passengers per day in summer",
+      "City walls have no shade and are brutal in midday heat (90\u00b0F+)",
+      "Tender port when busy \u2014 can have long waits for tenders",
       "Marble streets get dangerously slippery when wet",
-      "Cable car to Mt. Srđ has long lines when cruise ships in",
-      "Croatia uses Kuna (not Euro) — bring cash or expect poor exchange rates"
+      "Cable car to Mt. Sr\u0111 has long lines when cruise ships in",
+      "Croatia uses Kuna (not Euro) \u2014 bring cash or expect poor exchange rates"
     ],
     "packing_nudges": [
       "Walking shoes with excellent traction (marble streets are slick)",
       "Sun protection for wall walk (zero shade for 1.5 hours)",
-      "Water bottle (bring onto walls — limited access to water)",
+      "Water bottle (bring onto walls \u2014 limited access to water)",
       "Hat that won't blow off (windy on walls)",
       "Modest clothing for church visits",
       "Cash in Kuna for small purchases"
@@ -14830,7 +14983,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "32-66°F cool Scottish climate",
+      "temp_range": "32-66\u00b0F cool Scottish climate",
       "humidity": "Moderate to high",
       "rain": "Distributed year-round; frequent drizzle",
       "wind": "Can be strong; exposed coastal location",
@@ -14868,14 +15021,14 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "Dunedin has strong Scottish heritage — the name means Edinburgh",
+      "Dunedin has strong Scottish heritage \u2014 the name means Edinburgh",
       "Otago Peninsula has royal albatross, penguins, and seals",
       "Baldwin Street is the world's steepest residential street",
-      "Larnach Castle is NZ's only castle — worth visiting",
+      "Larnach Castle is NZ's only castle \u2014 worth visiting",
       "The Cadbury chocolate factory tour is a popular attraction"
     ],
     "packing_nudges": [
-      "Warm layers essential — it's NZ's coolest city",
+      "Warm layers essential \u2014 it's NZ's coolest city",
       "Waterproof jacket",
       "Warm hat and scarf",
       "Sturdy walking shoes",
@@ -14983,7 +15136,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "52-83°F subtropical",
+      "temp_range": "52-83\u00b0F subtropical",
       "humidity": "High summer; moderate winter",
       "rain": "Wet summers (Oct-Mar); dry winters",
       "wind": "Moderate coastal breezes",
@@ -15029,7 +15182,7 @@
       "Shark nets protect main beaches but check conditions",
       "Indian cultural influence makes Durban's cuisine unique",
       "The Golden Mile beachfront is walkable and scenic",
-      "Winter is mild and sunny — ideal for sightseeing"
+      "Winter is mild and sunny \u2014 ideal for sightseeing"
     ],
     "packing_nudges": [
       "Light clothing for summer",
@@ -15140,7 +15293,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "57-80°F — mild oceanic year-round",
+      "temp_range": "57-80\u00b0F \u2014 mild oceanic year-round",
       "humidity": "Moderate to high",
       "rain": "Distributed year-round; slightly drier Sep-Dec",
       "wind": "Trade winds; can be strong",
@@ -15172,15 +15325,15 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "The Moai statues are the entire reason to visit — allow a full day minimum",
-      "Rapa Nui National Park covers much of the island — entrance fee required",
-      "The island is extremely remote — 2,300 miles from Chile",
+      "The Moai statues are the entire reason to visit \u2014 allow a full day minimum",
+      "Rapa Nui National Park covers much of the island \u2014 entrance fee required",
+      "The island is extremely remote \u2014 2,300 miles from Chile",
       "Ahu Tongariki (15 moai at sunrise) is the most photographed site",
       "Rapa Nui culture is Polynesian, not South American"
     ],
     "packing_nudges": [
       "Light layers for mild climate",
-      "Wind layer — trade winds are persistent",
+      "Wind layer \u2014 trade winds are persistent",
       "Comfortable walking shoes for volcanic terrain",
       "Sunscreen and hat",
       "Rain jacket"
@@ -15287,10 +15440,10 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "33-66°F — Scotland's dramatic capital",
+      "temp_range": "33-66\u00b0F \u2014 Scotland's dramatic capital",
       "humidity": "High (70-83%)",
       "rain": "Year-round; slightly drier May-Jun",
-      "wind": "Can be very windy — exposed position",
+      "wind": "Can be very windy \u2014 exposed position",
       "daylight": "7-17.5 hours"
     },
     "best_months_for": {
@@ -15322,15 +15475,15 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "Edinburgh Festival (Aug) is world's largest arts festival — book everything early",
+      "Edinburgh Festival (Aug) is world's largest arts festival \u2014 book everything early",
       "Castle dominates skyline and is worth the entry fee",
-      "Arthur's Seat hike offers 360° views — volcanic peak",
+      "Arthur's Seat hike offers 360\u00b0 views \u2014 volcanic peak",
       "Royal Mile connects Castle to Holyrood Palace",
       "Whisky experiences range from tourist traps to genuine gems"
     ],
     "packing_nudges": [
-      "Waterproof jacket — essential",
-      "Layers — wind on Castle Hill is fierce",
+      "Waterproof jacket \u2014 essential",
+      "Layers \u2014 wind on Castle Hill is fierce",
       "Comfortable shoes for Old Town cobblestones",
       "Festival tickets booked in advance (Aug)"
     ],
@@ -15437,7 +15590,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "22-61°F glacial fjord",
+      "temp_range": "22-61\u00b0F glacial fjord",
       "humidity": "High",
       "rain": "Frequent year-round",
       "wind": "Glacial winds; cold blasts near ice",
@@ -15478,8 +15631,8 @@
     "catches_off_guard": [
       "Dawes Glacier calving is spectacular from the ship",
       "Icebergs in the fjord can prevent ships from getting close",
-      "Harbor seals often rest on ice floes — bring binoculars",
-      "This is a scenic cruising day — no port stop",
+      "Harbor seals often rest on ice floes \u2014 bring binoculars",
+      "This is a scenic cruising day \u2014 no port stop",
       "The fjord walls rise 2,000+ feet on either side"
     ],
     "packing_nudges": [
@@ -15591,7 +15744,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "46-79°F — Baja California Mediterranean",
+      "temp_range": "46-79\u00b0F \u2014 Baja California Mediterranean",
       "humidity": "Moderate; coastal influence",
       "rain": "Winter rains (Dec-Mar); dry summers",
       "wind": "Moderate coastal breezes",
@@ -15639,10 +15792,10 @@
       "La Bufadora (blowhole) is a popular natural attraction",
       "Street tacos and fish tacos here are legendary",
       "Most cruise ships from LA stop here on short Mexican Riviera cruises",
-      "The Riviera del Pacífico is a historic 1930s casino/cultural center"
+      "The Riviera del Pac\u00edfico is a historic 1930s casino/cultural center"
     ],
     "packing_nudges": [
-      "Light layers — coastal fog is common mornings",
+      "Light layers \u2014 coastal fog is common mornings",
       "Light jacket for evenings",
       "Comfortable walking shoes",
       "Sunscreen",
@@ -15750,7 +15903,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "-17 to 73°F — extreme subarctic continental",
+      "temp_range": "-17 to 73\u00b0F \u2014 extreme subarctic continental",
       "humidity": "Very low summer; higher winter",
       "rain": "Light year-round; summer thunderstorms",
       "wind": "Light to moderate",
@@ -15794,10 +15947,10 @@
       "Midnight sun in June means the sun barely sets",
       "Northern Lights are best viewed Sep-Mar",
       "Chena Hot Springs is a popular excursion year-round",
-      "Summer can actually be quite warm — 80°F+ is possible in July"
+      "Summer can actually be quite warm \u2014 80\u00b0F+ is possible in July"
     ],
     "packing_nudges": [
-      "Extreme warm layers for winter (-40°F possible)",
+      "Extreme warm layers for winter (-40\u00b0F possible)",
       "Light layers for summer (can be warm)",
       "Insect repellent for summer mosquitoes",
       "Sunscreen for midnight sun",
@@ -15906,10 +16059,10 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "30-55°F — windswept sub-Antarctic",
+      "temp_range": "30-55\u00b0F \u2014 windswept sub-Antarctic",
       "humidity": "High year-round",
       "rain": "Frequent light rain and drizzle",
-      "wind": "Extremely strong — one of windiest places on Earth",
+      "wind": "Extremely strong \u2014 one of windiest places on Earth",
       "daylight": "7.5-17 hours (seasonal)"
     },
     "best_months_for": {
@@ -15951,15 +16104,15 @@
       "Aug"
     ],
     "catches_off_guard": [
-      "Five penguin species breed here — rockhopper, gentoo, Magellanic, king, macaroni",
-      "Stanley is a very British town — red phone boxes, pubs, fish and chips",
+      "Five penguin species breed here \u2014 rockhopper, gentoo, Magellanic, king, macaroni",
+      "Stanley is a very British town \u2014 red phone boxes, pubs, fish and chips",
       "The 1982 Falklands War history is sensitively presented at museums",
-      "Wind is the defining feature — it never stops",
+      "Wind is the defining feature \u2014 it never stops",
       "Volunteer Point (king penguin colony) requires a 4x4 excursion"
     ],
     "packing_nudges": [
       "Windproof waterproof jacket essential",
-      "Warm layers — wind chill is brutal",
+      "Warm layers \u2014 wind chill is brutal",
       "Warm hat, gloves, neck protection",
       "Sturdy waterproof boots",
       "Binoculars for wildlife"
@@ -16066,7 +16219,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "71-89°F year-round",
+      "temp_range": "71-89\u00b0F year-round",
       "humidity": "Moderate (70-78%)",
       "rain": "Drier Dec-Apr; wet May-Jun and Sep-Oct",
       "wind": "Trades and sea breezes",
@@ -16118,7 +16271,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Sep",
         "Oct"
@@ -16224,7 +16377,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "71-89°F year-round",
+      "temp_range": "71-89\u00b0F year-round",
       "humidity": "Moderate (70-78%)",
       "rain": "Drier Dec-Apr; wet May-Jun and Sep-Oct",
       "wind": "Trades and sea breezes",
@@ -16262,7 +16415,7 @@
       "Oct"
     ],
     "catches_off_guard": [
-      "Georgian architecture — best-preserved in Caribbean",
+      "Georgian architecture \u2014 best-preserved in Caribbean",
       "Luminous Lagoon bioluminescence tour",
       "Purpose-built port with genuine town character",
       "Water Square historic center",
@@ -16276,7 +16429,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Sep",
         "Oct"
@@ -16382,7 +16535,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "67-86°F year-round tropical",
+      "temp_range": "67-86\u00b0F year-round tropical",
       "humidity": "High; drier Jun-Oct",
       "rain": "Wet season Nov-Apr; dry May-Oct",
       "wind": "Trade winds provide relief",
@@ -16430,8 +16583,8 @@
       "Cyclone season (Nov-Apr) can seriously disrupt cruise itineraries",
       "Fijian hospitality (bula!) is genuine and warm",
       "Kava ceremony participation is a cultural must",
-      "Coral reefs are easily damaged — tread carefully",
-      "Sunday is sacred — many businesses close and noise is frowned upon"
+      "Coral reefs are easily damaged \u2014 tread carefully",
+      "Sunday is sacred \u2014 many businesses close and noise is frowned upon"
     ],
     "packing_nudges": [
       "Light breathable clothing",
@@ -16442,7 +16595,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Nov – Apr (South Pacific cyclone season)",
+      "hurricane_season": "Nov \u2013 Apr (South Pacific cyclone season)",
       "peak_risk_months": [
         "Jan",
         "Feb",
@@ -16548,7 +16701,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "22-67°F — innermost Aurlandsfjord",
+      "temp_range": "22-67\u00b0F \u2014 innermost Aurlandsfjord",
       "humidity": "Moderate to high (58-77%)",
       "rain": "Wet year-round; very wet autumn",
       "wind": "Sheltered fjord",
@@ -16592,15 +16745,15 @@
       "Mar"
     ],
     "catches_off_guard": [
-      "Flåm Railway is one of world's steepest rail lines",
+      "Fl\u00e5m Railway is one of world's steepest rail lines",
       "Stegastein viewpoint has glass platform over fjord",
-      "Village is tiny — most time spent on excursions",
-      "Nærøyfjord (UNESCO) kayaking is magical",
-      "Ægir BrewPub is in a Viking-style building"
+      "Village is tiny \u2014 most time spent on excursions",
+      "N\u00e6r\u00f8yfjord (UNESCO) kayaking is magical",
+      "\u00c6gir BrewPub is in a Viking-style building"
     ],
     "packing_nudges": [
       "Waterproof jacket",
-      "Warm layers — cool even summer",
+      "Warm layers \u2014 cool even summer",
       "Camera for railway scenery",
       "Cash for small village shops"
     ],
@@ -16707,10 +16860,10 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "72-88°F year-round warm",
+      "temp_range": "72-88\u00b0F year-round warm",
       "humidity": "Moderate to high; drier second half",
       "rain": "Wet season Feb-May; very dry Jul-Nov",
-      "wind": "Strong trade winds — popular for kitesurfing",
+      "wind": "Strong trade winds \u2014 popular for kitesurfing",
       "daylight": "11-13 hours seasonal"
     },
     "best_months_for": {
@@ -16744,11 +16897,11 @@
       "Apr"
     ],
     "catches_off_guard": [
-      "Fortaleza is Brazil's kitesurfing capital — world-class conditions",
+      "Fortaleza is Brazil's kitesurfing capital \u2014 world-class conditions",
       "Beach Park water park is a popular excursion",
       "Jangada (traditional fishing boat) rides are unique",
       "The beach culture is vibrant year-round",
-      "Cashew fruit is everywhere — try the juice"
+      "Cashew fruit is everywhere \u2014 try the juice"
     ],
     "packing_nudges": [
       "Light beach clothing",
@@ -16859,7 +17012,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "63-89°F year-round",
+      "temp_range": "63-89\u00b0F year-round",
       "humidity": "Moderate to high (70-79%)",
       "rain": "Brief showers; heaviest Jun-Oct",
       "wind": "Easterly trades",
@@ -16911,7 +17064,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Sep",
         "Oct"
@@ -17017,7 +17170,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "45-88°F Mediterranean climate",
+      "temp_range": "45-88\u00b0F Mediterranean climate",
       "humidity": "Low summer; moderate winter",
       "rain": "Wet winter (Jun-Aug); very dry summer",
       "wind": "Strong afternoon sea breeze (Fremantle Doctor)",
@@ -17058,10 +17211,10 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "The Fremantle Doctor (afternoon sea breeze) drops temps 15°F+ in minutes",
+      "The Fremantle Doctor (afternoon sea breeze) drops temps 15\u00b0F+ in minutes",
       "Rottnest Island (quokkas!) is a must-visit but ferry can be rough",
-      "Perth is 30 min from Fremantle — accessible by train",
-      "Summer is hot and dry — bushfire risk exists",
+      "Perth is 30 min from Fremantle \u2014 accessible by train",
+      "Summer is hot and dry \u2014 bushfire risk exists",
       "The Swan Valley wine region is an easy day trip"
     ],
     "packing_nudges": [
@@ -17173,8 +17326,8 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "77-91°F; hot humid tropical climate year-round",
-      "humidity": "High (67-77%) — oppressive during summer months",
+      "temp_range": "77-91\u00b0F; hot humid tropical climate year-round",
+      "humidity": "High (67-77%) \u2014 oppressive during summer months",
       "rain": "Heavy afternoon thunderstorms Jun-Oct, brief but intense",
       "wind": "Light ocean breezes; stronger during storms",
       "daylight": "10-14 hours; fairly consistent year-round"
@@ -17220,10 +17373,10 @@
     ],
     "catches_off_guard": [
       "Daily afternoon thunderstorms in summer with dangerous lightning",
-      "Hurricane season is real — cruises may be cancelled Sep-Oct",
-      "Port area is industrial — beach is a taxi/Uber ride away",
-      "Traffic can be brutal — allow buffer time to return to ship",
-      "Humidity makes 90°F feel dangerously hot",
+      "Hurricane season is real \u2014 cruises may be cancelled Sep-Oct",
+      "Port area is industrial \u2014 beach is a taxi/Uber ride away",
+      "Traffic can be brutal \u2014 allow buffer time to return to ship",
+      "Humidity makes 90\u00b0F feel dangerously hot",
       "Indoor spaces are over-air-conditioned (bring layers)"
     ],
     "packing_nudges": [
@@ -17236,7 +17389,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Aug",
         "Sep",
@@ -17343,7 +17496,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "37-87°F four seasons",
+      "temp_range": "37-87\u00b0F four seasons",
       "humidity": "Muggy Jun-Sep; moderate otherwise",
       "rain": "Rainy season Jun-Jul (tsuyu); driest Oct-Dec",
       "wind": "Moderate; winter winds from continent",
@@ -17391,7 +17544,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "May – Nov (Western Pacific typhoon season)",
+      "hurricane_season": "May \u2013 Nov (Western Pacific typhoon season)",
       "peak_risk_months": [
         "Aug",
         "Sep",
@@ -17497,7 +17650,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "54-77°F — subtropical island, mild year-round",
+      "temp_range": "54-77\u00b0F \u2014 subtropical island, mild year-round",
       "humidity": "Moderate (66-71%)",
       "rain": "Drier May-Sep; wetter Oct-Feb",
       "wind": "Trade winds moderate",
@@ -17536,12 +17689,12 @@
       "Levada walks (irrigation channel trails) are Madeira's highlight",
       "Toboggan ride from Monte is touristy but fun",
       "Garden of Monte Palace is world-class",
-      "Madeira wine tasting is a must — unlike any other wine",
-      "Weather varies by altitude — mountains can be cool and cloudy"
+      "Madeira wine tasting is a must \u2014 unlike any other wine",
+      "Weather varies by altitude \u2014 mountains can be cool and cloudy"
     ],
     "packing_nudges": [
       "Sturdy hiking shoes for levadas",
-      "Light rain jacket — mountain weather changes",
+      "Light rain jacket \u2014 mountain weather changes",
       "Layers for altitude changes",
       "Cash for toboggan ride and wine tasting"
     ],
@@ -17648,8 +17801,8 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "63-91°F; hot humid summers, mild winters with cold fronts",
-      "humidity": "High (72-76%) — Gulf Coast humidity year-round",
+      "temp_range": "63-91\u00b0F; hot humid summers, mild winters with cold fronts",
+      "humidity": "High (72-76%) \u2014 Gulf Coast humidity year-round",
       "rain": "Scattered showers year-round; heaviest May-Oct",
       "wind": "Steady Gulf breezes; stronger during fronts and hurricanes",
       "daylight": "10-14 hours; consistent year-round"
@@ -17692,10 +17845,10 @@
       "Sep"
     ],
     "catches_off_guard": [
-      "Hurricane season is serious — August-September cancellations possible",
+      "Hurricane season is serious \u2014 August-September cancellations possible",
       "Winter cold fronts can drop temps to 40s overnight in Dec-Feb",
       "Beach water is brown (Mississippi sediment), not Caribbean blue",
-      "Summer heat + humidity makes 90°F feel like 105°F+",
+      "Summer heat + humidity makes 90\u00b0F feel like 105\u00b0F+",
       "Seaweed and jellyfish common in summer",
       "Houston traffic can cause delays returning to port"
     ],
@@ -17709,7 +17862,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic/Gulf)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic/Gulf)",
       "peak_risk_months": [
         "Aug",
         "Sep"
@@ -17815,7 +17968,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "73-90°F tropical lake",
+      "temp_range": "73-90\u00b0F tropical lake",
       "humidity": "High year-round",
       "rain": "Dry Jan-Apr; wet May-Dec",
       "wind": "Light; sheltered by surrounding jungle",
@@ -17843,8 +17996,8 @@
       "Gatun Lake was the world's largest artificial lake when created (1913)",
       "The lake provides the water that operates the canal locks",
       "Monkey Island excursions offer wildlife viewing",
-      "Rainforest surrounds the lake — incredible biodiversity",
-      "Ships anchor here during canal transits — an unusual experience"
+      "Rainforest surrounds the lake \u2014 incredible biodiversity",
+      "Ships anchor here during canal transits \u2014 an unusual experience"
     ],
     "packing_nudges": [
       "Light breathable clothing",
@@ -17955,7 +18108,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "24-72°F — Hanseatic Baltic city",
+      "temp_range": "24-72\u00b0F \u2014 Hanseatic Baltic city",
       "humidity": "Moderate to high (65-86%)",
       "rain": "Year-round; wetter summer",
       "wind": "Baltic coast",
@@ -18002,9 +18155,9 @@
       "Feb"
     ],
     "catches_off_guard": [
-      "Long Market (Długi Targ) is one of Europe's most photogenic streets",
-      "Solidarity movement started here at Gdańsk Shipyard",
-      "Amber capital of the world — but watch for fakes",
+      "Long Market (D\u0142ugi Targ) is one of Europe's most photogenic streets",
+      "Solidarity movement started here at Gda\u0144sk Shipyard",
+      "Amber capital of the world \u2014 but watch for fakes",
       "Rebuilt meticulously after WWII destruction",
       "Malbork Castle (day trip) is world's largest brick castle"
     ],
@@ -18117,7 +18270,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "21-66°F — UNESCO fjord",
+      "temp_range": "21-66\u00b0F \u2014 UNESCO fjord",
       "humidity": "Moderate to high (58-76%)",
       "rain": "Wet year-round; slightly drier spring",
       "wind": "Sheltered fjord but can funnel",
@@ -18156,16 +18309,16 @@
     ],
     "catches_off_guard": [
       "Seven Sisters and Bridal Veil waterfalls are iconic",
-      "Tender port — small village",
+      "Tender port \u2014 small village",
       "Trollstigen mountain road is spectacular but nauseating",
       "Dalsnibba viewpoint (if accessible) offers 1500m views",
-      "Very limited infrastructure — small village with cafes"
+      "Very limited infrastructure \u2014 small village with cafes"
     ],
     "packing_nudges": [
       "Waterproof jacket and pants",
-      "Warm layers — fjord is cool even summer",
+      "Warm layers \u2014 fjord is cool even summer",
       "Hiking boots",
-      "Camera — scenery is jaw-dropping"
+      "Camera \u2014 scenery is jaw-dropping"
     ],
     "hazards": {
       "hurricane_zone": false,
@@ -18270,7 +18423,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "38-82°F — maritime Ligurian climate",
+      "temp_range": "38-82\u00b0F \u2014 maritime Ligurian climate",
       "humidity": "Moderate (57-71%)",
       "rain": "Wetter than south Med; autumn heaviest",
       "wind": "Sheltered by Apennines but occasionally gusty",
@@ -18309,11 +18462,11 @@
       "Genoa's old town (centro storico) is Europe's largest medieval quarter",
       "Birthplace of Columbus and pesto",
       "Via Garibaldi palaces are UNESCO-listed",
-      "City is genuinely Italian — not touristy",
+      "City is genuinely Italian \u2014 not touristy",
       "Focaccia di Recco is not to be missed"
     ],
     "packing_nudges": [
-      "Comfortable walking shoes — old town is hilly",
+      "Comfortable walking shoes \u2014 old town is hilly",
       "Umbrella for rain",
       "Light layers",
       "Cash for bakeries and small shops"
@@ -18421,7 +18574,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "48-84°F — British territory at Med entrance",
+      "temp_range": "48-84\u00b0F \u2014 British territory at Med entrance",
       "humidity": "Moderate (52-76%)",
       "rain": "Dry summers; wet winters",
       "wind": "Levante (east) and Poniente (west) are dominant",
@@ -18457,7 +18610,7 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "Barbary macaques are famous but can be aggressive — secure belongings",
+      "Barbary macaques are famous but can be aggressive \u2014 secure belongings",
       "Rock of Gibraltar cable car or walk to top",
       "Levante wind creates dramatic cloud cap on the Rock",
       "Military tunnels are extensive and fascinating",
@@ -18572,7 +18725,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "40-72°F — Bay of Biscay, cool and green",
+      "temp_range": "40-72\u00b0F \u2014 Bay of Biscay, cool and green",
       "humidity": "High (73-78%)",
       "rain": "Wet year-round; slightly less in summer",
       "wind": "Bay of Biscay winds",
@@ -18613,14 +18766,14 @@
       "Feb"
     ],
     "catches_off_guard": [
-      "Asturian cider (sidra) poured from height — technique matters",
-      "NOT Mediterranean — expect cool and rainy",
+      "Asturian cider (sidra) poured from height \u2014 technique matters",
+      "NOT Mediterranean \u2014 expect cool and rainy",
       "San Lorenzo Beach is urban but pleasant",
       "Fabada asturiana (bean stew) is hearty local dish",
-      "Gijón is industrial but has genuine character"
+      "Gij\u00f3n is industrial but has genuine character"
     ],
     "packing_nudges": [
-      "Waterproof jacket — essential",
+      "Waterproof jacket \u2014 essential",
       "Layers for changeable weather",
       "Comfortable walking shoes",
       "Appetite for Asturian cuisine"
@@ -18728,7 +18881,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "30-54°F — Beagle Channel glaciers",
+      "temp_range": "30-54\u00b0F \u2014 Beagle Channel glaciers",
       "humidity": "Very high",
       "rain": "Extremely wet year-round",
       "wind": "Strong; Southern Ocean influence",
@@ -18763,7 +18916,7 @@
     "catches_off_guard": [
       "Five glaciers descend from the Darwin Cordillera to the Beagle Channel",
       "Named after European countries: Spain, France, Germany, Italy, Netherlands",
-      "The glaciers are retreating visibly — compare to historical photos",
+      "The glaciers are retreating visibly \u2014 compare to historical photos",
       "This is a scenic cruising highlight between Ushuaia and Cape Horn",
       "Wildlife (cormorants, seals) is visible from the ship"
     ],
@@ -18876,7 +19029,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "22-61°F — glacial fjord climate",
+      "temp_range": "22-61\u00b0F \u2014 glacial fjord climate",
       "humidity": "High year-round",
       "rain": "Frequent year-round; heaviest Sep-Nov",
       "wind": "Glacial winds create dramatic cold blasts",
@@ -18920,11 +19073,11 @@
       "Apr"
     ],
     "catches_off_guard": [
-      "Ships cruise the bay — there's no port to disembark (scenic cruising)",
-      "Calving glaciers are dramatic and unpredictable — keep cameras ready",
+      "Ships cruise the bay \u2014 there's no port to disembark (scenic cruising)",
+      "Calving glaciers are dramatic and unpredictable \u2014 keep cameras ready",
       "Rangers board the ship to narrate the journey",
       "Humpback whales, sea otters, bears, and eagles are commonly spotted",
-      "The glaciers have retreated significantly — compare to historic photos"
+      "The glaciers have retreated significantly \u2014 compare to historic photos"
     ],
     "packing_nudges": [
       "Warm waterproof layers",
@@ -19035,7 +19188,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "34-65°F — Scottish lowlands maritime",
+      "temp_range": "34-65\u00b0F \u2014 Scottish lowlands maritime",
       "humidity": "High year-round",
       "rain": "Frequent; slightly drier Apr-Jun",
       "wind": "Can be strong",
@@ -19079,7 +19232,7 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "Glasgow has world-class free museums — Kelvingrove and Riverside Museum",
+      "Glasgow has world-class free museums \u2014 Kelvingrove and Riverside Museum",
       "The city's Victorian architecture is stunning",
       "Charles Rennie Mackintosh's art nouveau buildings are unique",
       "Glasgow's music scene rivals any city in the UK",
@@ -19194,7 +19347,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "68-91°F year-round warm",
+      "temp_range": "68-91\u00b0F year-round warm",
       "humidity": "Lower dry season; extreme monsoon",
       "rain": "Monsoon Jun-Sep is torrential; Oct-May bone dry",
       "wind": "Strong monsoon winds Jun-Sep",
@@ -19236,9 +19389,9 @@
       "Aug"
     ],
     "catches_off_guard": [
-      "Goa monsoon is spectacular but beaches are dangerous — swimming banned",
+      "Goa monsoon is spectacular but beaches are dangerous \u2014 swimming banned",
       "Many beach shacks and restaurants close entirely Jun-Sep",
-      "Christmas/New Year is peak season — extremely crowded and expensive",
+      "Christmas/New Year is peak season \u2014 extremely crowded and expensive",
       "Portuguese heritage creates a unique non-Indian feel",
       "Water sports only operate Nov-May"
     ],
@@ -19251,7 +19404,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Nov – Apr (Indian Ocean cyclone season)",
+      "hurricane_season": "Nov \u2013 Apr (Indian Ocean cyclone season)",
       "peak_risk_months": [
         "Jan",
         "Feb",
@@ -19357,7 +19510,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "26-71°F — west coast, maritime",
+      "temp_range": "26-71\u00b0F \u2014 west coast, maritime",
       "humidity": "Moderate to high (63-84%)",
       "rain": "Wet year-round; slightly drier spring",
       "wind": "North Sea influence; can be windy",
@@ -19397,12 +19550,12 @@
     "catches_off_guard": [
       "Liseberg amusement park is Scandinavia's largest",
       "Haga district has cobblestones and giant cinnamon buns",
-      "Fish church (Feskekörka) is a must for seafood",
+      "Fish church (Feskek\u00f6rka) is a must for seafood",
       "Gothenburg archipelago ferries are free with transit pass",
-      "Second city to Stockholm — less pretentious, equally charming"
+      "Second city to Stockholm \u2014 less pretentious, equally charming"
     ],
     "packing_nudges": [
-      "Waterproof jacket — wetter than Stockholm",
+      "Waterproof jacket \u2014 wetter than Stockholm",
       "Layers",
       "Comfortable walking shoes",
       "Transit pass for archipelago ferries"
@@ -19510,7 +19663,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "57-82°F — warm year-round",
+      "temp_range": "57-82\u00b0F \u2014 warm year-round",
       "humidity": "Moderate (59-65%)",
       "rain": "Very little; driest May-Aug",
       "wind": "Trade winds moderate temperatures",
@@ -19673,7 +19826,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "72-90°F year-round",
+      "temp_range": "72-90\u00b0F year-round",
       "humidity": "Moderate to high (71-80%)",
       "rain": "Brief showers; heaviest Sep-Nov",
       "wind": "Steady trades Dec-Apr",
@@ -19710,10 +19863,10 @@
       "Oct"
     ],
     "catches_off_guard": [
-      "Tender port — rough seas can cancel calls",
+      "Tender port \u2014 rough seas can cancel calls",
       "Seven Mile Beach sun intense even overcast",
       "Stingray City crowded in peak season",
-      "Prices are high — not budget-friendly",
+      "Prices are high \u2014 not budget-friendly",
       "Tap water is desalinated and safe"
     ],
     "packing_nudges": [
@@ -19724,7 +19877,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Sep",
         "Oct"
@@ -19830,7 +19983,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "72-90°F year-round",
+      "temp_range": "72-90\u00b0F year-round",
       "humidity": "Moderate (69-76%)",
       "rain": "Dry Dec-Apr; brief summer showers",
       "wind": "Steady trades; can be windy",
@@ -19877,21 +20030,21 @@
       "Oct"
     ],
     "catches_off_guard": [
-      "Cruise center self-contained — real Grand Turk is walkable",
+      "Cruise center self-contained \u2014 real Grand Turk is walkable",
       "Humpback whales pass close Jan-Apr",
       "Wall dive starts 300 yards offshore",
-      "Island tiny and flat — walkable",
+      "Island tiny and flat \u2014 walkable",
       "Columbus allegedly landed here 1492"
     ],
     "packing_nudges": [
       "Reef-safe sunscreen",
       "Water shoes",
-      "Cash — limited ATMs",
+      "Cash \u2014 limited ATMs",
       "Wind protection for beach gear"
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Sep",
         "Oct"
@@ -19997,9 +20150,9 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "33-65°F — gateway to Glasgow and Highlands",
+      "temp_range": "33-65\u00b0F \u2014 gateway to Glasgow and Highlands",
       "humidity": "High (72-83%)",
-      "rain": "Very wet year-round — one of UK's wettest",
+      "rain": "Very wet year-round \u2014 one of UK's wettest",
       "wind": "Atlantic exposure",
       "daylight": "7-17.5 hours"
     },
@@ -20033,10 +20186,10 @@
     ],
     "catches_off_guard": [
       "Gateway to Glasgow (45 min) and Loch Lomond",
-      "Glasgow is underrated — world-class museums (many free)",
+      "Glasgow is underrated \u2014 world-class museums (many free)",
       "Highland day trips to Loch Lomond or Stirling Castle",
-      "Greenock itself has limited attractions — plan excursion",
-      "Rain is almost guaranteed — pack accordingly"
+      "Greenock itself has limited attractions \u2014 plan excursion",
+      "Rain is almost guaranteed \u2014 pack accordingly"
     ],
     "packing_nudges": [
       "Waterproof everything",
@@ -20147,7 +20300,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "72-87°F year-round",
+      "temp_range": "72-87\u00b0F year-round",
       "humidity": "Moderate to high (68-78%)",
       "rain": "Dry Jan-May; wet Jun-Nov",
       "wind": "Moderate trades",
@@ -20194,8 +20347,8 @@
       "Oct"
     ],
     "catches_off_guard": [
-      "South of main hurricane belt — rarely hit",
-      "Known as Spice Island — nutmeg everywhere",
+      "South of main hurricane belt \u2014 rarely hit",
+      "Known as Spice Island \u2014 nutmeg everywhere",
       "Underwater sculpture park is unique",
       "Grand Anse Beach is world-class",
       "St. George's is prettiest Caribbean capital"
@@ -20208,7 +20361,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Sep",
         "Oct"
@@ -20314,7 +20467,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "71-88°F year-round",
+      "temp_range": "71-88\u00b0F year-round",
       "humidity": "Moderate to high (72-80%)",
       "rain": "Wet Jun-Nov; mountains wetter",
       "wind": "Moderate trades",
@@ -20353,21 +20506,21 @@
       "Sep"
     ],
     "catches_off_guard": [
-      "Two islands — Grande-Terre flat/dry, Basse-Terre volcanic/wet",
-      "La Soufrière volcano hike is challenging",
+      "Two islands \u2014 Grande-Terre flat/dry, Basse-Terre volcanic/wet",
+      "La Soufri\u00e8re volcano hike is challenging",
       "Euro is currency, French primary language",
       "Rum agricole from sugarcane juice",
       "Jacques Cousteau Reserve is exceptional"
     ],
     "packing_nudges": [
-      "Hiking boots for Soufrière",
+      "Hiking boots for Soufri\u00e8re",
       "Rain jacket for mountains",
       "Reef-safe sunscreen",
       "Basic French phrases help"
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Sep",
         "Oct"
@@ -20473,7 +20626,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "74-87°F year-round tropical",
+      "temp_range": "74-87\u00b0F year-round tropical",
       "humidity": "High year-round",
       "rain": "Dry season Jan-May; wet season Jul-Nov",
       "wind": "Trade winds; typhoon risk",
@@ -20514,10 +20667,10 @@
       "Oct"
     ],
     "catches_off_guard": [
-      "Guam is a US territory — dollars accepted, no passport needed for US citizens",
+      "Guam is a US territory \u2014 dollars accepted, no passport needed for US citizens",
       "Typhoon season (Jul-Nov) is a real concern",
       "Two Lovers Point is the iconic lookout",
-      "Chamorro culture and cuisine are unique — try kelaguen",
+      "Chamorro culture and cuisine are unique \u2014 try kelaguen",
       "Duty-free shopping attracts visitors from Asia"
     ],
     "packing_nudges": [
@@ -20529,7 +20682,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jul – Nov (Western Pacific typhoon season)",
+      "hurricane_season": "Jul \u2013 Nov (Western Pacific typhoon season)",
       "peak_risk_months": [
         "Aug",
         "Sep",
@@ -20635,7 +20788,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "67-89°F year-round warm",
+      "temp_range": "67-89\u00b0F year-round warm",
       "humidity": "Higher wet season; moderate dry",
       "rain": "Wet season Dec-Apr; dry May-Nov",
       "wind": "Light; river breezes",
@@ -20671,10 +20824,10 @@
       "Mar"
     ],
     "catches_off_guard": [
-      "Parque Seminario is full of free-roaming iguanas — surreal",
-      "Malecón 2000 boardwalk along the Guayas River is the main attraction",
-      "Guayaquil is the gateway to the Galápagos (flights depart here)",
-      "Las Peñas neighborhood has colorful hillside steps",
+      "Parque Seminario is full of free-roaming iguanas \u2014 surreal",
+      "Malec\u00f3n 2000 boardwalk along the Guayas River is the main attraction",
+      "Guayaquil is the gateway to the Gal\u00e1pagos (flights depart here)",
+      "Las Pe\u00f1as neighborhood has colorful hillside steps",
       "The city has improved dramatically in safety and tourism infrastructure"
     ],
     "packing_nudges": [
@@ -20786,7 +20939,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "57-90°F seasonal variation",
+      "temp_range": "57-90\u00b0F seasonal variation",
       "humidity": "High year-round; foggiest Feb-Apr",
       "rain": "Wet season May-Sep; driest Oct-Jan",
       "wind": "Monsoon winds can be strong",
@@ -20825,7 +20978,7 @@
       "Rough seas can cancel tender operations in winter",
       "Summer heat on a boat with no shade is punishing",
       "Typhoons can force itinerary changes Jul-Oct",
-      "October is the sweet spot — clear skies, calm seas, moderate heat"
+      "October is the sweet spot \u2014 clear skies, calm seas, moderate heat"
     ],
     "packing_nudges": [
       "Rain gear year-round",
@@ -20836,7 +20989,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "May – Nov (Western Pacific typhoon season)",
+      "hurricane_season": "May \u2013 Nov (Western Pacific typhoon season)",
       "peak_risk_months": [
         "Aug",
         "Sep",
@@ -20942,7 +21095,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "45-90°F — Mediterranean meets desert",
+      "temp_range": "45-90\u00b0F \u2014 Mediterranean meets desert",
       "humidity": "Moderate (56-68%)",
       "rain": "Wet Oct-Mar; bone-dry Jun-Sep",
       "wind": "Sea breezes; hamsin (hot desert wind) in spring",
@@ -20980,16 +21133,16 @@
       "Aug"
     ],
     "catches_off_guard": [
-      "Bahá'í Gardens are stunningly terraced — free but timed entry",
+      "Bah\u00e1'\u00ed Gardens are stunningly terraced \u2014 free but timed entry",
       "Gateway to Acre, Nazareth, and Sea of Galilee",
-      "Hamsin (sharav) hot wind can push temps above 100°F",
-      "Security checks at port are thorough — allow extra time",
+      "Hamsin (sharav) hot wind can push temps above 100\u00b0F",
+      "Security checks at port are thorough \u2014 allow extra time",
       "Sabbath (Fri sunset to Sat sunset) limits public transport"
     ],
     "packing_nudges": [
       "Modest clothing for religious sites",
       "Sunscreen and hat",
-      "Comfortable walking shoes for Bahá'í terraces",
+      "Comfortable walking shoes for Bah\u00e1'\u00ed terraces",
       "Cash for Arab markets in Acre"
     ],
     "hazards": {
@@ -21095,7 +21248,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "16-64°F — mountain-sheltered fjord",
+      "temp_range": "16-64\u00b0F \u2014 mountain-sheltered fjord",
       "humidity": "Lower than coastal towns",
       "rain": "Drier than other SE Alaska ports",
       "wind": "Can be strong; mountain-funneled",
@@ -21248,7 +21401,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "18-77°F — Hokkaido maritime climate",
+      "temp_range": "18-77\u00b0F \u2014 Hokkaido maritime climate",
       "humidity": "Moderate; foggy summers",
       "rain": "Evenly distributed; snow Nov-Mar",
       "wind": "Strong winter winds",
@@ -21288,7 +21441,7 @@
     ],
     "catches_off_guard": [
       "Cherry blossoms arrive a month later than Tokyo (early May)",
-      "Mt. Hakodate night view is one of Japan's best — dress warmly",
+      "Mt. Hakodate night view is one of Japan's best \u2014 dress warmly",
       "Snow and ice make winter walking treacherous",
       "Fresh seafood at morning market is a must",
       "Summer is pleasantly cool compared to southern Japan"
@@ -21402,7 +21555,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "17-75°F — Maritime Canadian climate",
+      "temp_range": "17-75\u00b0F \u2014 Maritime Canadian climate",
       "humidity": "Moderate; foggy springs",
       "rain": "Distributed; fog common spring/summer",
       "wind": "Can be strong; exposed Atlantic coast",
@@ -21442,14 +21595,14 @@
       "Mar"
     ],
     "catches_off_guard": [
-      "Peggys Cove lighthouse is Nova Scotia's most iconic image — 1 hour drive",
-      "Halifax has deep Titanic connections — cemetery and Maritime Museum",
+      "Peggys Cove lighthouse is Nova Scotia's most iconic image \u2014 1 hour drive",
+      "Halifax has deep Titanic connections \u2014 cemetery and Maritime Museum",
       "The waterfront boardwalk is excellent for walking and dining",
       "Alexander Keith's brewery tour is a fun local experience",
-      "Fog can roll in fast — it's atmospheric but pack a layer"
+      "Fog can roll in fast \u2014 it's atmospheric but pack a layer"
     ],
     "packing_nudges": [
-      "Layers — maritime climate is changeable",
+      "Layers \u2014 maritime climate is changeable",
       "Waterproof jacket",
       "Comfortable walking shoes",
       "Warm layers for fog and wind",
@@ -21557,7 +21710,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "28-72°F — northern German port city",
+      "temp_range": "28-72\u00b0F \u2014 northern German port city",
       "humidity": "Moderate to high (67-87%)",
       "rain": "Year-round; wetter summer/autumn",
       "wind": "North Sea influence; can be gusty",
@@ -21597,15 +21750,15 @@
       "Feb"
     ],
     "catches_off_guard": [
-      "Miniatur Wunderland is world's largest model railway — book ahead",
+      "Miniatur Wunderland is world's largest model railway \u2014 book ahead",
       "Speicherstadt warehouse district is UNESCO",
       "Elbphilharmonie concert hall plaza has free access",
-      "Reeperbahn is famous red-light district — vibrant nightlife",
+      "Reeperbahn is famous red-light district \u2014 vibrant nightlife",
       "Fish Market (Sunday mornings) is legendary"
     ],
     "packing_nudges": [
       "Waterproof jacket",
-      "Layers — weather changes quickly",
+      "Layers \u2014 weather changes quickly",
       "Comfortable walking shoes",
       "Umbrella"
     ],
@@ -21712,7 +21865,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "72-88°F year-round",
+      "temp_range": "72-88\u00b0F year-round",
       "humidity": "High (76-83%)",
       "rain": "Dry Feb-May; wet Jun-Nov",
       "wind": "Sea breezes; sheltered by reef",
@@ -21756,11 +21909,11 @@
       "Reef-safe sunscreen",
       "Waterproof phone case",
       "Water shoes",
-      "Towel — limited supply"
+      "Towel \u2014 limited supply"
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Sep",
         "Oct"
@@ -21866,7 +22019,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "15-71°F — Baltic capital, maritime",
+      "temp_range": "15-71\u00b0F \u2014 Baltic capital, maritime",
       "humidity": "Moderate to high (62-88%)",
       "rain": "Year-round; slightly drier spring",
       "wind": "Baltic winds; sea breezes",
@@ -21908,11 +22061,11 @@
       "Feb"
     ],
     "catches_off_guard": [
-      "Design District is Helsinki's hallmark — architecture and shops",
+      "Design District is Helsinki's hallmark \u2014 architecture and shops",
       "Market Square (Kauppatori) waterfront is social center",
       "Suomenlinna sea fortress (UNESCO) is worth the ferry",
-      "White Nights in June — nearly 19 hours of daylight",
-      "Sauna culture is sacred — public saunas welcome visitors"
+      "White Nights in June \u2014 nearly 19 hours of daylight",
+      "Sauna culture is sacred \u2014 public saunas welcome visitors"
     ],
     "packing_nudges": [
       "Layers for changeable weather",
@@ -22023,7 +22176,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "46-87°F — Crete's capital",
+      "temp_range": "46-87\u00b0F \u2014 Crete's capital",
       "humidity": "Low to moderate (39-70%)",
       "rain": "Dry May-Sep; moderate winter rain",
       "wind": "Meltemi Jul-Aug; can be strong",
@@ -22068,16 +22221,16 @@
       "Aug"
     ],
     "catches_off_guard": [
-      "Knossos (Minoan palace) is the must-see — go early",
-      "Samariá Gorge hike is 10 miles — full day commitment",
-      "Cretan cuisine is exceptional — raki flows freely",
-      "Heraklion itself is not the prettiest — explore beyond",
+      "Knossos (Minoan palace) is the must-see \u2014 go early",
+      "Samari\u00e1 Gorge hike is 10 miles \u2014 full day commitment",
+      "Cretan cuisine is exceptional \u2014 raki flows freely",
+      "Heraklion itself is not the prettiest \u2014 explore beyond",
       "Venetian harbor and fortress are the old town highlights"
     ],
     "packing_nudges": [
       "Sturdy walking shoes for Knossos",
       "Sunscreen and hat for ruins",
-      "Water bottle — summer is hot",
+      "Water bottle \u2014 summer is hot",
       "Cash for village tavernas"
     ],
     "hazards": {
@@ -22183,8 +22336,8 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "62-83°F year-round tropical — wet side",
-      "humidity": "High year-round — lush rainforest climate",
+      "temp_range": "62-83\u00b0F year-round tropical \u2014 wet side",
+      "humidity": "High year-round \u2014 lush rainforest climate",
       "rain": "Very wet year-round (126+ inches); wettest Mar-Apr",
       "wind": "Trade wind exposure; frequent showers",
       "daylight": "11-13.5 hours seasonal"
@@ -22222,14 +22375,14 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "Hawai'i Volcanoes National Park is the #1 excursion — allow a full day",
-      "Hilo is the wettest city in the US — rain is nearly guaranteed",
+      "Hawai'i Volcanoes National Park is the #1 excursion \u2014 allow a full day",
+      "Hilo is the wettest city in the US \u2014 rain is nearly guaranteed",
       "Rainbow Falls and Akaka Falls are easily accessible waterfalls",
       "The Hilo Farmers Market (Wed/Sat) is excellent",
       "Lava landscapes contrast dramatically with lush rainforest"
     ],
     "packing_nudges": [
-      "Rain jacket essential — Hilo is very wet",
+      "Rain jacket essential \u2014 Hilo is very wet",
       "Comfortable waterproof walking shoes",
       "Light breathable clothing",
       "Sturdy shoes for volcano park trails",
@@ -22337,7 +22490,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "35-87°F four seasons",
+      "temp_range": "35-87\u00b0F four seasons",
       "humidity": "Muggy Jun-Sep; moderate otherwise",
       "rain": "Rainy season Jun-Jul; dry autumn",
       "wind": "Light to moderate",
@@ -22373,7 +22526,7 @@
       "Aug"
     ],
     "catches_off_guard": [
-      "Miyajima Island (floating torii gate) requires a ferry — check tides",
+      "Miyajima Island (floating torii gate) requires a ferry \u2014 check tides",
       "Peace Memorial Park is deeply moving but entirely outdoors",
       "Autumn colors at Miyajima peak mid-November",
       "Summer heat makes outdoor memorial visits challenging",
@@ -22388,7 +22541,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "May – Nov (Western Pacific typhoon season)",
+      "hurricane_season": "May \u2013 Nov (Western Pacific typhoon season)",
       "peak_risk_months": [
         "Aug",
         "Sep",
@@ -22494,7 +22647,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "72-93°F year-round heat",
+      "temp_range": "72-93\u00b0F year-round heat",
       "humidity": "High year-round; peak in wet season",
       "rain": "Wet season May-Nov; torrential afternoon storms",
       "wind": "Light monsoon winds",
@@ -22532,8 +22685,8 @@
     ],
     "catches_off_guard": [
       "Afternoon thunderstorms in wet season are intense but brief",
-      "Traffic is relentless — crossing streets takes nerve",
-      "The heat never lets up — hydrate constantly",
+      "Traffic is relentless \u2014 crossing streets takes nerve",
+      "The heat never lets up \u2014 hydrate constantly",
       "Cu Chi Tunnels have no shade or AC",
       "Tet holiday closures catch visitors off guard"
     ],
@@ -22646,7 +22799,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "72-93°F year-round heat",
+      "temp_range": "72-93\u00b0F year-round heat",
       "humidity": "High year-round; peak in wet season",
       "rain": "Wet season May-Nov; torrential afternoon storms",
       "wind": "Light monsoon winds",
@@ -22689,10 +22842,10 @@
     ],
     "catches_off_guard": [
       "Afternoon thunderstorms in wet season are intense but brief",
-      "Traffic never stops for rain — flooding is common",
+      "Traffic never stops for rain \u2014 flooding is common",
       "Tet (Lunar New Year) shuts down many businesses for a week",
-      "The heat index regularly exceeds 105°F year-round",
-      "Cu Chi Tunnels have no shade — go early morning"
+      "The heat index regularly exceeds 105\u00b0F year-round",
+      "Cu Chi Tunnels have no shade \u2014 go early morning"
     ],
     "packing_nudges": [
       "Light breathable clothing",
@@ -22803,7 +22956,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "37-72°F cool maritime (Southern Hemisphere)",
+      "temp_range": "37-72\u00b0F cool maritime (Southern Hemisphere)",
       "humidity": "Moderate year-round",
       "rain": "Distributed year-round; drier summer",
       "wind": "Can be strong; Southern Ocean influence",
@@ -22845,7 +22998,7 @@
       "Tasmania is much cooler than mainland Australia",
       "MONA (Museum of Old and New Art) is world-class and indoor",
       "Salamanca Market (Saturday) is a highlight",
-      "Mt. Wellington summit can be 20°F colder than the city",
+      "Mt. Wellington summit can be 20\u00b0F colder than the city",
       "Fresh seafood (especially oysters) is superb year-round"
     ],
     "packing_nudges": [
@@ -22957,10 +23110,10 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "36-64°F — Welsh coast maritime",
+      "temp_range": "36-64\u00b0F \u2014 Welsh coast maritime",
       "humidity": "High year-round",
       "rain": "Frequent; slightly drier Apr-Jun",
-      "wind": "Very windy — exposed Irish Sea coast",
+      "wind": "Very windy \u2014 exposed Irish Sea coast",
       "daylight": "8-17 hours seasonal"
     },
     "best_months_for": {
@@ -22994,14 +23147,169 @@
       "Beaumaris Castle (nearby) is a UNESCO World Heritage site",
       "The South Stack Lighthouse has dramatic cliff walks",
       "Anglesey island has excellent coastal paths",
-      "Wales has its own language — road signs are bilingual"
+      "Wales has its own language \u2014 road signs are bilingual"
     ],
     "packing_nudges": [
       "Warm waterproof layers essential",
       "Sturdy hiking shoes for Snowdonia",
-      "Wind layer — it's very windy",
+      "Wind layer \u2014 it's very windy",
       "Warm hat and gloves",
       "Rain jacket"
+    ],
+    "hazards": {
+      "hurricane_zone": false
+    },
+    "cruise_seasons": {
+      "high": [
+        "Jun",
+        "Jul",
+        "Aug"
+      ],
+      "transitional": [
+        "May",
+        "Sep"
+      ],
+      "low": [
+        "Oct",
+        "Nov",
+        "Dec",
+        "Jan",
+        "Feb",
+        "Mar",
+        "Apr"
+      ]
+    }
+  },
+  "homer": {
+    "tier": 1,
+    "timezone": "America/Anchorage",
+    "_source": "High/low/rain_days: Homer Airport NOAA 1991-2020 (Wikipedia climate table, session 2026-09-03). Humidity: Seward entry in this file (Kenai Peninsula nearest existing station).",
+    "monthly_averages": {
+      "jan": {
+        "high_f": 32,
+        "low_f": 19,
+        "rain_days": 14,
+        "humidity": 75
+      },
+      "feb": {
+        "high_f": 35,
+        "low_f": 22,
+        "rain_days": 12,
+        "humidity": 73
+      },
+      "mar": {
+        "high_f": 37,
+        "low_f": 23,
+        "rain_days": 11,
+        "humidity": 71
+      },
+      "apr": {
+        "high_f": 46,
+        "low_f": 31,
+        "rain_days": 10,
+        "humidity": 68
+      },
+      "may": {
+        "high_f": 54,
+        "low_f": 38,
+        "rain_days": 10,
+        "humidity": 70
+      },
+      "jun": {
+        "high_f": 59,
+        "low_f": 45,
+        "rain_days": 10,
+        "humidity": 72
+      },
+      "jul": {
+        "high_f": 63,
+        "low_f": 49,
+        "rain_days": 12,
+        "humidity": 75
+      },
+      "aug": {
+        "high_f": 63,
+        "low_f": 48,
+        "rain_days": 14,
+        "humidity": 77
+      },
+      "sep": {
+        "high_f": 57,
+        "low_f": 42,
+        "rain_days": 16,
+        "humidity": 78
+      },
+      "oct": {
+        "high_f": 47,
+        "low_f": 33,
+        "rain_days": 15,
+        "humidity": 76
+      },
+      "nov": {
+        "high_f": 38,
+        "low_f": 25,
+        "rain_days": 15,
+        "humidity": 76
+      },
+      "dec": {
+        "high_f": 34,
+        "low_f": 21,
+        "rain_days": 17,
+        "humidity": 76
+      }
+    },
+    "at_a_glance": {
+      "temp_range": "19-63\u00b0F \u2014 drier Kenai than SE Alaska",
+      "humidity": "Moderate for Alaska",
+      "rain": "~24 in/year; wettest Sep-Dec",
+      "wind": "Kachemak Bay can blow",
+      "daylight": "6-19 hours (seasonal)"
+    },
+    "best_months_for": {
+      "halibut_fishing": [
+        "May",
+        "Jun",
+        "Jul",
+        "Aug"
+      ],
+      "spit_walking": [
+        "Jun",
+        "Jul",
+        "Aug"
+      ],
+      "bear_viewing": [
+        "Jul",
+        "Aug"
+      ],
+      "city_walking": [
+        "Jun",
+        "Jul",
+        "Aug"
+      ],
+      "low_crowds": [
+        "May",
+        "Sep"
+      ]
+    },
+    "avoid_months": [
+      "Nov",
+      "Dec",
+      "Jan",
+      "Feb",
+      "Mar"
+    ],
+    "catches_off_guard": [
+      "Homer Spit is a 4.5-mile gravel bar \u2014 wind is the weather",
+      "This is one of the drier Alaska cruise ports",
+      "Halibut charters book out in June-July",
+      "The dock can be a tender or a small-ship pier depending on the ship",
+      "Summer nights are short, not warm"
+    ],
+    "packing_nudges": [
+      "Wind layer for the Spit",
+      "Waterproof shoes for gravel",
+      "Layers; 50s\u00b0F is a July afternoon",
+      "Binoculars for the bay"
     ],
     "hazards": {
       "hurricane_zone": false
@@ -23105,7 +23413,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "36-69°F — Normandy estuary",
+      "temp_range": "36-69\u00b0F \u2014 Normandy estuary",
       "humidity": "High; maritime",
       "rain": "Frequent; slightly drier May-Jul",
       "wind": "Moderate; Seine estuary exposure",
@@ -23147,7 +23455,7 @@
     "catches_off_guard": [
       "Honfleur's old harbor is one of France's most painted scenes",
       "Impressionist painters (Monet, Boudin) were inspired by its light",
-      "The Vieux Bassin is the picturesque harbor — restaurants line both sides",
+      "The Vieux Bassin is the picturesque harbor \u2014 restaurants line both sides",
       "Calvados and cider tasting are Norman specialties",
       "D-Day beaches are accessible as a day trip"
     ],
@@ -23156,7 +23464,7 @@
       "Waterproof jacket",
       "Comfortable walking shoes for cobblestones",
       "Light warm layer even in summer",
-      "Camera — it's extremely photogenic"
+      "Camera \u2014 it's extremely photogenic"
     ],
     "hazards": {
       "hurricane_zone": false
@@ -23260,7 +23568,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "55-87°F seasonal range",
+      "temp_range": "55-87\u00b0F seasonal range",
       "humidity": "High summer (80%+), moderate winter",
       "rain": "Monsoon rains May-Sep; dry cool winters",
       "wind": "Strong winter monsoon winds Dec-Feb",
@@ -23320,7 +23628,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "May – Nov (Western Pacific typhoon season)",
+      "hurricane_season": "May \u2013 Nov (Western Pacific typhoon season)",
       "peak_risk_months": [
         "Aug",
         "Sep",
@@ -23426,11 +23734,11 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "17-56°F — North Cape, 71°N",
+      "temp_range": "17-56\u00b0F \u2014 North Cape, 71\u00b0N",
       "humidity": "High (74-81%)",
       "rain": "Year-round; wetter late summer",
       "wind": "Very exposed; strong winds common",
-      "daylight": "0-24 hours — extreme variation"
+      "daylight": "0-24 hours \u2014 extreme variation"
     },
     "best_months_for": {
       "midnight_sun": [
@@ -23471,12 +23779,12 @@
       "North Cape (Nordkapp) is northernmost point accessible by road",
       "Midnight Sun visible May 14 - Jul 30",
       "Sami culture and reindeer herding in area",
-      "Wind at North Cape can be ferocious — hold onto hats",
-      "Very limited infrastructure — small fishing village"
+      "Wind at North Cape can be ferocious \u2014 hold onto hats",
+      "Very limited infrastructure \u2014 small fishing village"
     ],
     "packing_nudges": [
       "Heavy windproof jacket",
-      "Warm layers — even summer can be cold",
+      "Warm layers \u2014 even summer can be cold",
       "Gloves and hat for North Cape",
       "Camera for midnight sun"
     ],
@@ -23583,8 +23891,8 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "65-88°F year-round tropical paradise",
-      "humidity": "Moderate — trade winds provide relief",
+      "temp_range": "65-88\u00b0F year-round tropical paradise",
+      "humidity": "Moderate \u2014 trade winds provide relief",
       "rain": "Drier May-Sep; slightly wetter Nov-Mar",
       "wind": "Persistent NE trade winds",
       "daylight": "11-13.5 hours seasonal"
@@ -23629,11 +23937,11 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "North Shore surf is enormous in winter — watch, don't swim unless expert",
-      "Diamond Head hike is iconic but hot and exposed — go early",
-      "Waikiki Beach is crowded but convenient — try less-known beaches",
-      "Pearl Harbor requires advance reservations — book early",
-      "Trade winds keep humidity manageable — Kona winds (southerly) don't"
+      "North Shore surf is enormous in winter \u2014 watch, don't swim unless expert",
+      "Diamond Head hike is iconic but hot and exposed \u2014 go early",
+      "Waikiki Beach is crowded but convenient \u2014 try less-known beaches",
+      "Pearl Harbor requires advance reservations \u2014 book early",
+      "Trade winds keep humidity manageable \u2014 Kona winds (southerly) don't"
     ],
     "packing_nudges": [
       "Light beach clothing",
@@ -23744,7 +24052,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "68-91°F year-round warm",
+      "temp_range": "68-91\u00b0F year-round warm",
       "humidity": "Low dry season; high wet",
       "rain": "Dry Nov-May; wet Jun-Oct",
       "wind": "Light; occasional summer squalls",
@@ -23784,8 +24092,8 @@
       "Sep"
     ],
     "catches_off_guard": [
-      "Huatulco has 9 bays and 36 beaches — most accessible only by boat",
-      "The area is an eco-tourism destination — more natural than Cancún",
+      "Huatulco has 9 bays and 36 beaches \u2014 most accessible only by boat",
+      "The area is an eco-tourism destination \u2014 more natural than Canc\u00fan",
       "Copalita archaeological site is a lesser-known Zapotec ruin",
       "Coffee plantations in the mountains are a unique excursion",
       "National Huatulco Park protects coral reefs offshore"
@@ -23799,7 +24107,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "May 15 – Nov 30 (East Pacific)",
+      "hurricane_season": "May 15 \u2013 Nov 30 (East Pacific)",
       "peak_risk_months": [
         "Aug",
         "Sep",
@@ -23905,7 +24213,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "19-60°F — glacial bay",
+      "temp_range": "19-60\u00b0F \u2014 glacial bay",
       "humidity": "High",
       "rain": "Frequent year-round",
       "wind": "Glacial winds; intense near the face",
@@ -23939,11 +24247,11 @@
       "Apr"
     ],
     "catches_off_guard": [
-      "Hubbard Glacier is North America's largest tidewater glacier — 6 miles wide",
-      "Calving events are dramatic — ice chunks the size of buildings",
+      "Hubbard Glacier is North America's largest tidewater glacier \u2014 6 miles wide",
+      "Calving events are dramatic \u2014 ice chunks the size of buildings",
       "Ships maintain a safe distance but the scale is still awe-inspiring",
       "The glacier is actually advancing, unlike most glaciers",
-      "This is purely scenic cruising — no disembarkation"
+      "This is purely scenic cruising \u2014 no disembarkation"
     ],
     "packing_nudges": [
       "Warmest waterproof layers you have",
@@ -24054,7 +24362,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "50-99°F Red Sea desert climate",
+      "temp_range": "50-99\u00b0F Red Sea desert climate",
       "humidity": "Very low year-round",
       "rain": "Essentially zero",
       "wind": "Moderate; can be strong and gusty",
@@ -24098,9 +24406,9 @@
       "Aug"
     ],
     "catches_off_guard": [
-      "Summer heat is extreme — even the sea is warm (85°F+)",
+      "Summer heat is extreme \u2014 even the sea is warm (85\u00b0F+)",
       "Wind can cancel boat trips to Giftun Island",
-      "Coral reefs are world-class but easily damaged — be careful",
+      "Coral reefs are world-class but easily damaged \u2014 be careful",
       "The resort strip is spread over 20+ miles along the coast",
       "Desert excursions require serious sun protection"
     ],
@@ -24213,7 +24521,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "39-86°F — sunniest Croatian island",
+      "temp_range": "39-86\u00b0F \u2014 sunniest Croatian island",
       "humidity": "Moderate (47-67%)",
       "rain": "Dry Jun-Aug; wetter autumn/winter",
       "wind": "Bura (northeast) in winter; Jugo (south)",
@@ -24252,14 +24560,14 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "2700+ hours of sunshine per year — one of sunniest Med islands",
-      "Hvar Town is Croatia's St. Tropez — upscale and busy",
+      "2700+ hours of sunshine per year \u2014 one of sunniest Med islands",
+      "Hvar Town is Croatia's St. Tropez \u2014 upscale and busy",
       "Pakleni Islands accessible by water taxi for quieter beaches",
       "Lavender fields in interior bloom Jun-Jul",
       "Fortica fortress above town has panoramic views"
     ],
     "packing_nudges": [
-      "Sunscreen — intense sun",
+      "Sunscreen \u2014 intense sun",
       "Water shoes for rocky beaches",
       "Smart casual for restaurants",
       "Cash for water taxis"
@@ -24367,7 +24675,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "43-86°F — club season is summer",
+      "temp_range": "43-86\u00b0F \u2014 club season is summer",
       "humidity": "Moderate (52-74%)",
       "rain": "Dry May-Sep; wetter autumn/winter",
       "wind": "Variable; calm summers",
@@ -24402,8 +24710,8 @@
     "avoid_months": [],
     "catches_off_guard": [
       "Known for nightlife but Dalt Vila (old town) is UNESCO",
-      "Beaches range from party to pristine — choose wisely",
-      "Sunset at Café del Mar is iconic but overcrowded",
+      "Beaches range from party to pristine \u2014 choose wisely",
+      "Sunset at Caf\u00e9 del Mar is iconic but overcrowded",
       "Northern beaches (Portinatx) are family-friendly",
       "Formentera day trip by ferry is worth it"
     ],
@@ -24516,7 +24824,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "25-61°F — remote Tlingit community",
+      "temp_range": "25-61\u00b0F \u2014 remote Tlingit community",
       "humidity": "High year-round",
       "rain": "Frequent; similar to Juneau",
       "wind": "Moderate",
@@ -24563,9 +24871,9 @@
     "catches_off_guard": [
       "Icy Strait Point is privately owned by the Huna Tlingit",
       "The ZipRider is one of the world's longest ziplines",
-      "Whale watching here is excellent — Point Adolphus is prime habitat",
+      "Whale watching here is excellent \u2014 Point Adolphus is prime habitat",
       "The restored 1912 cannery is the cultural center",
-      "No town to explore — it's a purpose-built cruise destination"
+      "No town to explore \u2014 it's a purpose-built cruise destination"
     ],
     "packing_nudges": [
       "Waterproof layers",
@@ -24676,8 +24984,8 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "60-85°F subtropical island",
-      "humidity": "High year-round — rainforest island",
+      "temp_range": "60-85\u00b0F subtropical island",
+      "humidity": "High year-round \u2014 rainforest island",
       "rain": "Very wet Dec-Mar; drier Jun-Aug",
       "wind": "Light; sheltered by mainland",
       "daylight": "10.5-13.5 hours (Southern Hemisphere)"
@@ -24719,10 +25027,10 @@
       "Feb"
     ],
     "catches_off_guard": [
-      "Ilhabela means 'Beautiful Island' — it lives up to the name",
+      "Ilhabela means 'Beautiful Island' \u2014 it lives up to the name",
       "Over 300 waterfalls on the island",
       "The Atlantic Forest is a UNESCO Biosphere Reserve",
-      "Mosquitoes and borrachudos (biting flies) are fierce — bring repellent",
+      "Mosquitoes and borrachudos (biting flies) are fierce \u2014 bring repellent",
       "It's a tender port with limited pier capacity"
     ],
     "packing_nudges": [
@@ -24834,7 +25142,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "19-85°F extreme seasonal range",
+      "temp_range": "19-85\u00b0F extreme seasonal range",
       "humidity": "Muggy Jul-Aug; dry crisp fall",
       "rain": "Monsoon Jul-Aug; very dry winter",
       "wind": "Strong winter winds; tidal flats exposed",
@@ -24871,7 +25179,7 @@
       "Feb"
     ],
     "catches_off_guard": [
-      "Incheon is Seoul's port — budget 1+ hour transfer time",
+      "Incheon is Seoul's port \u2014 budget 1+ hour transfer time",
       "Extreme tidal range (up to 30 ft) affects port operations",
       "Winter wind chill can be brutal",
       "Summer monsoon rains are heavy and persistent",
@@ -24986,7 +25294,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "26-63°F sheltered coastal waterway",
+      "temp_range": "26-63\u00b0F sheltered coastal waterway",
       "humidity": "High year-round",
       "rain": "Frequent; typical SE Alaska",
       "wind": "Generally sheltered; calm waters",
@@ -25024,7 +25332,7 @@
       "The Inside Passage is a 1,000-mile sheltered waterway along the coast",
       "Calm waters make it a comfortable cruise even for those prone to seasickness",
       "Eagles, whales, and bears can be spotted from the ship",
-      "Many ships transit at night — you may miss scenery if not timed well",
+      "Many ships transit at night \u2014 you may miss scenery if not timed well",
       "The passage is shared with ferries and fishing boats"
     ],
     "packing_nudges": [
@@ -25136,7 +25444,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "33-63°F — Scottish Highlands coast",
+      "temp_range": "33-63\u00b0F \u2014 Scottish Highlands coast",
       "humidity": "Moderate to high",
       "rain": "Frequent; drier spring",
       "wind": "Can be strong; exposed firth location",
@@ -25178,7 +25486,7 @@
       "Invergordon is the gateway to Loch Ness and the Scottish Highlands",
       "Loch Ness (Urquhart Castle) is about 1 hour drive",
       "Dalmore and Glenmorangie distilleries are nearby",
-      "The Highlands are vast — excursions cover a lot of ground",
+      "The Highlands are vast \u2014 excursions cover a lot of ground",
       "Midges (biting insects) are fierce Jun-Sep in the Highlands"
     ],
     "packing_nudges": [
@@ -25186,7 +25494,7 @@
       "Midge repellent essential Jun-Sep",
       "Sturdy walking shoes",
       "Warm hat and gloves",
-      "Layers — Highland weather changes fast"
+      "Layers \u2014 Highland weather changes fast"
     ],
     "hazards": {
       "hurricane_zone": false
@@ -25290,10 +25598,10 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "23-55°F — Westfjords subarctic",
+      "temp_range": "23-55\u00b0F \u2014 Westfjords subarctic",
       "humidity": "Moderate to high",
       "rain": "Frequent; snow in winter",
-      "wind": "Can be extreme — narrow fjord funneling",
+      "wind": "Can be extreme \u2014 narrow fjord funneling",
       "daylight": "2-24 hours (extreme polar variation)"
     },
     "best_months_for": {
@@ -25328,8 +25636,8 @@
       "Feb"
     ],
     "catches_off_guard": [
-      "The Westfjords are Iceland's most remote region — dramatic and wild",
-      "Arctic foxes are commonly seen — Iceland's only native land mammal",
+      "The Westfjords are Iceland's most remote region \u2014 dramatic and wild",
+      "Arctic foxes are commonly seen \u2014 Iceland's only native land mammal",
       "Midnight sun in June means 24-hour daylight",
       "Dynjandi waterfall (1 hour drive) is one of Iceland's most beautiful",
       "The town is tiny but has a great folk music scene"
@@ -25338,7 +25646,7 @@
       "Warm waterproof layers essential",
       "Sturdy hiking boots",
       "Warm hat, gloves, scarf",
-      "Wind layer — fjord winds can be fierce",
+      "Wind layer \u2014 fjord winds can be fierce",
       "Sunscreen for long daylight"
     ],
     "hazards": {
@@ -25443,7 +25751,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "35-84°F — continental winters, hot summers",
+      "temp_range": "35-84\u00b0F \u2014 continental winters, hot summers",
       "humidity": "Moderate to high (59-78%)",
       "rain": "Year-round; drier Jun-Aug",
       "wind": "Northeast winds from Black Sea can be chilly",
@@ -25484,13 +25792,13 @@
     ],
     "catches_off_guard": [
       "Bosphorus strait cruise is unforgettable",
-      "Hagia Sophia and Blue Mosque queues are long — go early",
+      "Hagia Sophia and Blue Mosque queues are long \u2014 go early",
       "Grand Bazaar is overwhelming but negotiation is expected",
-      "Summer heat in old city is intense — hydrate",
-      "City straddles two continents — geography matters"
+      "Summer heat in old city is intense \u2014 hydrate",
+      "City straddles two continents \u2014 geography matters"
     ],
     "packing_nudges": [
-      "Comfortable walking shoes — hilly city",
+      "Comfortable walking shoes \u2014 hilly city",
       "Modest clothing for mosques (scarves available)",
       "Sunscreen for summer",
       "Cash in Turkish lira for markets"
@@ -25598,7 +25906,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "42-92°F — north Florida subtropical",
+      "temp_range": "42-92\u00b0F \u2014 north Florida subtropical",
       "humidity": "Moderate to high; muggy summers",
       "rain": "Summer thunderstorms dominant; drier fall/winter",
       "wind": "Light; sea breezes",
@@ -25631,9 +25939,9 @@
     "avoid_months": [],
     "catches_off_guard": [
       "Jacksonville is the largest city by area in the continental US",
-      "Summer heat is intense — afternoon thunderstorms provide brief relief",
+      "Summer heat is intense \u2014 afternoon thunderstorms provide brief relief",
       "The Beaches (Atlantic Beach, Jacksonville Beach) are 20+ min from port",
-      "St. Augustine (America's oldest city) is 40 min south — worth the trip",
+      "St. Augustine (America's oldest city) is 40 min south \u2014 worth the trip",
       "The Cummer Museum of Art has beautiful riverside gardens"
     ],
     "packing_nudges": [
@@ -25645,7 +25953,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Sep",
         "Oct"
@@ -25750,7 +26058,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "74-89°F year-round tropical",
+      "temp_range": "74-89\u00b0F year-round tropical",
       "humidity": "High year-round; drier Jun-Sep",
       "rain": "Heavy wet season Dec-Mar; dry season Jun-Sep",
       "wind": "Light monsoon winds",
@@ -25784,9 +26092,9 @@
       "Feb"
     ],
     "catches_off_guard": [
-      "Jakarta traffic is among the worst in the world — plan for 2+ hour transfers",
+      "Jakarta traffic is among the worst in the world \u2014 plan for 2+ hour transfers",
       "Wet season flooding is common and can strand you",
-      "Air quality can be poor — check conditions",
+      "Air quality can be poor \u2014 check conditions",
       "The port (Tanjung Priok) is far from tourist areas",
       "Bogor botanical gardens are a cooler alternative"
     ],
@@ -25799,7 +26107,7 @@
     ],
     "hazards": {
       "hurricane_zone": false,
-      "note": "Wet season flooding is common and can strand you. Air quality can be poor — check conditions."
+      "note": "Wet season flooding is common and can strand you. Air quality can be poor \u2014 check conditions."
     },
     "cruise_seasons": {
       "high": [
@@ -25900,7 +26208,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "72-89°F year-round",
+      "temp_range": "72-89\u00b0F year-round",
       "humidity": "Moderate to high (71-79%)",
       "rain": "Two wet peaks: May-Jun and Sep-Nov",
       "wind": "Trades; sea breezes",
@@ -25951,7 +26259,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Sep",
         "Oct"
@@ -26057,10 +26365,10 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "35-85°F four seasons",
+      "temp_range": "35-85\u00b0F four seasons",
       "humidity": "Muggy Jul-Sep; moderate otherwise",
       "rain": "Spread throughout year; wettest Jul-Sep",
-      "wind": "Very windy — strongest in winter/spring",
+      "wind": "Very windy \u2014 strongest in winter/spring",
       "daylight": "10-14.5 hours seasonal"
     },
     "best_months_for": {
@@ -26095,7 +26403,7 @@
       "Aug"
     ],
     "catches_off_guard": [
-      "Jeju is extremely windy — bring a windbreaker always",
+      "Jeju is extremely windy \u2014 bring a windbreaker always",
       "The island's volcanic landscape is unlike mainland Korea",
       "Hallasan summit hike requires early start and good weather",
       "Tangerine season (Nov-Jan) is unique to Jeju",
@@ -26110,7 +26418,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "May – Nov (Western Pacific typhoon season)",
+      "hurricane_season": "May \u2013 Nov (Western Pacific typhoon season)",
       "peak_risk_months": [
         "Aug",
         "Sep",
@@ -26216,8 +26524,8 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "22-64°F — cool rainforest climate",
-      "humidity": "High year-round — temperate rainforest",
+      "temp_range": "22-64\u00b0F \u2014 cool rainforest climate",
+      "humidity": "High year-round \u2014 temperate rainforest",
       "rain": "Rain year-round (62+ inches/year); wettest Sep-Nov",
       "wind": "Moderate; Taku winds can be fierce",
       "daylight": "6-18.5 hours (extreme seasonal variation)"
@@ -26259,15 +26567,15 @@
       "Mar"
     ],
     "catches_off_guard": [
-      "Mendenhall Glacier is the top attraction — accessible by bus or tour",
-      "Rain is nearly constant — pack waterproof everything",
+      "Mendenhall Glacier is the top attraction \u2014 accessible by bus or tour",
+      "Rain is nearly constant \u2014 pack waterproof everything",
       "Whale watching (humpbacks) is reliable May-September",
       "The State Capitol is the only one without road access",
       "Mount Roberts Tramway offers alpine views directly from downtown"
     ],
     "packing_nudges": [
       "Waterproof jacket and pants essential",
-      "Layers — temperature varies with sun/cloud/wind",
+      "Layers \u2014 temperature varies with sun/cloud/wind",
       "Waterproof hiking boots",
       "Warm hat and gloves even in summer",
       "Binoculars for wildlife"
@@ -26374,7 +26682,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "37-87°F four seasons",
+      "temp_range": "37-87\u00b0F four seasons",
       "humidity": "Muggy Jun-Sep; moderate otherwise",
       "rain": "Very heavy rainy season Jun-Jul; active volcano ash",
       "wind": "Moderate; occasional ash fallout",
@@ -26411,7 +26719,7 @@
       "Aug"
     ],
     "catches_off_guard": [
-      "Sakurajima volcano is active — ash falls are common and unpredictable",
+      "Sakurajima volcano is active \u2014 ash falls are common and unpredictable",
       "Carry a face mask for volcanic ash days",
       "Rainy season (Jun-Jul) is extremely wet here",
       "The city has a subtropical feel despite its latitude",
@@ -26426,7 +26734,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "May – Nov (Western Pacific typhoon season)",
+      "hurricane_season": "May \u2013 Nov (Western Pacific typhoon season)",
       "peak_risk_months": [
         "Aug",
         "Sep",
@@ -26532,7 +26840,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "29-64°F — wettest city in Alaska",
+      "temp_range": "29-64\u00b0F \u2014 wettest city in Alaska",
       "humidity": "Very high year-round",
       "rain": "Rain 200+ days/year; wettest Sep-Nov",
       "wind": "Moderate; sheltered channel location",
@@ -26574,14 +26882,14 @@
       "Mar"
     ],
     "catches_off_guard": [
-      "Ketchikan gets 140+ inches of rain per year — embrace it",
+      "Ketchikan gets 140+ inches of rain per year \u2014 embrace it",
       "Creek Street (historic boardwalk) is the top walking attraction",
       "Totem Heritage Center has the world's largest collection of original totems",
       "Salmon run viewing is spectacular Jul-Sep at various creeks",
       "Misty Fjords is a stunning seaplane or boat excursion"
     ],
     "packing_nudges": [
-      "Full waterproof gear — jacket, pants, boots",
+      "Full waterproof gear \u2014 jacket, pants, boots",
       "Layers for variable temperatures",
       "Warm hat",
       "Waterproof daypack",
@@ -26689,7 +26997,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "65-90°F — warmest continental US",
+      "temp_range": "65-90\u00b0F \u2014 warmest continental US",
       "humidity": "Moderate (65-75%)",
       "rain": "Dry winter; wet summer thunderstorms",
       "wind": "Trades; occasional cold fronts Dec-Mar",
@@ -26733,10 +27041,10 @@
       "Sep"
     ],
     "catches_off_guard": [
-      "Dock is far from Duval Street — plan for walk",
+      "Dock is far from Duval Street \u2014 plan for walk",
       "Fantasy Fest (late Oct) is wild, not family-friendly",
-      "Key deer endangered — never feed",
-      "Walk or bike — parking impossible",
+      "Key deer endangered \u2014 never feed",
+      "Walk or bike \u2014 parking impossible",
       "Mallory Square sunset crowded but worth it"
     ],
     "packing_nudges": [
@@ -26747,7 +27055,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Sep",
         "Oct"
@@ -26853,7 +27161,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "27-71°F — Baltic gateway",
+      "temp_range": "27-71\u00b0F \u2014 Baltic gateway",
       "humidity": "Moderate to high (67-86%)",
       "rain": "Year-round; slightly drier spring",
       "wind": "Baltic winds; Kiel Week brings sailors",
@@ -26891,7 +27199,7 @@
       "Feb"
     ],
     "catches_off_guard": [
-      "Kiel Canal connects North Sea to Baltic — ships pass constantly",
+      "Kiel Canal connects North Sea to Baltic \u2014 ships pass constantly",
       "Kiel Week (late Jun) is world's largest sailing event",
       "Laboe Naval Memorial and submarine U-995 are worth visiting",
       "Gateway to Copenhagen ferry",
@@ -27006,10 +27314,10 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "34-60°F — Orkney Islands maritime",
+      "temp_range": "34-60\u00b0F \u2014 Orkney Islands maritime",
       "humidity": "High year-round",
       "rain": "Frequent; slightly drier May-Jul",
-      "wind": "Very windy — one of windiest UK locations",
+      "wind": "Very windy \u2014 one of windiest UK locations",
       "daylight": "6-19 hours (near midnight twilight in June)"
     },
     "best_months_for": {
@@ -27054,9 +27362,9 @@
     "packing_nudges": [
       "Warm windproof layers essential",
       "Waterproof jacket",
-      "Warm hat — the wind is relentless",
+      "Warm hat \u2014 the wind is relentless",
       "Sturdy shoes for archaeological sites",
-      "Layers — all four seasons in one day"
+      "Layers \u2014 all four seasons in one day"
     ],
     "hazards": {
       "hurricane_zone": false
@@ -27160,7 +27468,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "22-71°F — Lithuanian Baltic",
+      "temp_range": "22-71\u00b0F \u2014 Lithuanian Baltic",
       "humidity": "High (70-87%)",
       "rain": "Year-round; slightly drier spring",
       "wind": "Baltic winds",
@@ -27200,7 +27508,7 @@
     "catches_off_guard": [
       "Curonian Spit (UNESCO) is spectacular sand dune peninsula",
       "Old town is compact and charming",
-      "Smiltynė ferry connects to Curonian Spit",
+      "Smiltyn\u0117 ferry connects to Curonian Spit",
       "Lithuania's only port city",
       "Amber museum and galleries are highlights"
     ],
@@ -27313,7 +27621,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "36-87°F four seasons",
+      "temp_range": "36-87\u00b0F four seasons",
       "humidity": "Muggy Jun-Sep; pleasant otherwise",
       "rain": "Rainy season Jun-Jul; drier fall",
       "wind": "Light; sheltered by mountains",
@@ -27351,9 +27659,9 @@
     ],
     "catches_off_guard": [
       "Kobe beef restaurants book up fast during cruise season",
-      "The city sits between mountains and sea — weather can shift quickly",
+      "The city sits between mountains and sea \u2014 weather can shift quickly",
       "Summer humidity is oppressive for hillside walks",
-      "Port is very walkable — many attractions within walking distance",
+      "Port is very walkable \u2014 many attractions within walking distance",
       "Night views from Mt. Rokko are spectacular but cold in winter"
     ],
     "packing_nudges": [
@@ -27365,7 +27673,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "May – Nov (Western Pacific typhoon season)",
+      "hurricane_season": "May \u2013 Nov (Western Pacific typhoon season)",
       "peak_risk_months": [
         "Aug",
         "Sep",
@@ -27390,6 +27698,155 @@
         "Aug",
         "Jan",
         "Feb"
+      ]
+    }
+  },
+  "kodiak": {
+    "tier": 1,
+    "timezone": "America/Anchorage",
+    "_source": "High/low/rain_days: Kodiak Airport NOAA 1991-2020 (Wikipedia climate table, session 2026-09-03). Humidity: Sitka entry in this file (wet-maritime stand-in; Kodiak has no humidity series in this registry).",
+    "monthly_averages": {
+      "jan": {
+        "high_f": 36,
+        "low_f": 26,
+        "rain_days": 19,
+        "humidity": 78
+      },
+      "feb": {
+        "high_f": 38,
+        "low_f": 27,
+        "rain_days": 17,
+        "humidity": 77
+      },
+      "mar": {
+        "high_f": 39,
+        "low_f": 28,
+        "rain_days": 16,
+        "humidity": 75
+      },
+      "apr": {
+        "high_f": 45,
+        "low_f": 34,
+        "rain_days": 18,
+        "humidity": 75
+      },
+      "may": {
+        "high_f": 52,
+        "low_f": 40,
+        "rain_days": 16,
+        "humidity": 76
+      },
+      "jun": {
+        "high_f": 57,
+        "low_f": 46,
+        "rain_days": 16,
+        "humidity": 78
+      },
+      "jul": {
+        "high_f": 62,
+        "low_f": 50,
+        "rain_days": 15,
+        "humidity": 80
+      },
+      "aug": {
+        "high_f": 63,
+        "low_f": 50,
+        "rain_days": 15,
+        "humidity": 82
+      },
+      "sep": {
+        "high_f": 57,
+        "low_f": 44,
+        "rain_days": 17,
+        "humidity": 83
+      },
+      "oct": {
+        "high_f": 48,
+        "low_f": 36,
+        "rain_days": 18,
+        "humidity": 82
+      },
+      "nov": {
+        "high_f": 41,
+        "low_f": 30,
+        "rain_days": 17,
+        "humidity": 80
+      },
+      "dec": {
+        "high_f": 37,
+        "low_f": 26,
+        "rain_days": 20,
+        "humidity": 79
+      }
+    },
+    "at_a_glance": {
+      "temp_range": "26-63\u00b0F \u2014 maritime, wet",
+      "humidity": "High year-round",
+      "rain": "~78 in/year; ~200 precip days",
+      "wind": "Gulf of Alaska; gales common",
+      "daylight": "6.5-18 hours (seasonal)"
+    },
+    "best_months_for": {
+      "bear_viewing": [
+        "Jul",
+        "Aug"
+      ],
+      "fishing": [
+        "Jun",
+        "Jul",
+        "Aug"
+      ],
+      "city_walking": [
+        "Jun",
+        "Jul",
+        "Aug"
+      ],
+      "low_crowds": [
+        "May",
+        "Sep"
+      ]
+    },
+    "avoid_months": [
+      "Nov",
+      "Dec",
+      "Jan",
+      "Feb",
+      "Mar"
+    ],
+    "catches_off_guard": [
+      "Kodiak is not Southeast \u2014 it is a Gulf island with its own weather",
+      "Rain days rival Ketchikan even if the annual inches are lower",
+      "Bears are the inland draw; downtown is a working cannery town",
+      "Wind can cancel small-boat and floatplane trips",
+      "Cruise calls are fewer than Juneau/Ketchikan"
+    ],
+    "packing_nudges": [
+      "Waterproof jacket",
+      "Warm hat",
+      "Layers for 50s\u00b0F and rain",
+      "Grip shoes for wet docks"
+    ],
+    "hazards": {
+      "hurricane_zone": false
+    },
+    "cruise_seasons": {
+      "high": [
+        "Jun",
+        "Jul",
+        "Aug"
+      ],
+      "transitional": [
+        "May",
+        "Sep"
+      ],
+      "low": [
+        "Oct",
+        "Nov",
+        "Dec",
+        "Jan",
+        "Feb",
+        "Mar",
+        "Apr"
       ]
     }
   },
@@ -27471,7 +27928,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "73-90°F year-round tropical",
+      "temp_range": "73-90\u00b0F year-round tropical",
       "humidity": "High year-round",
       "rain": "Wettest Oct-Dec; driest Feb-Apr",
       "wind": "Northeast monsoon brings rain Oct-Dec",
@@ -27621,7 +28078,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "71-88°F year-round tropical",
+      "temp_range": "71-88\u00b0F year-round tropical",
       "humidity": "Lower than most of Indonesia in dry season",
       "rain": "Wet Nov-Mar; very dry May-Oct",
       "wind": "Can be strong in strait between islands",
@@ -27670,7 +28127,7 @@
     ],
     "catches_off_guard": [
       "Komodo dragons are active year-round but more visible in dry season",
-      "The trek to see dragons is exposed — no shade, extreme heat",
+      "The trek to see dragons is exposed \u2014 no shade, extreme heat",
       "Pink Beach is accessible only in calm seas (dry season)",
       "Strong currents in the strait make snorkeling conditions variable",
       "Park entrance fees are substantial and increasing"
@@ -27784,8 +28241,8 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "65-87°F — dry side of Big Island",
-      "humidity": "Low to moderate — drier than Hilo",
+      "temp_range": "65-87\u00b0F \u2014 dry side of Big Island",
+      "humidity": "Low to moderate \u2014 drier than Hilo",
       "rain": "Light year-round; drier than east side",
       "wind": "Moderate; sheltered by Mauna Kea",
       "daylight": "11-13.5 hours seasonal"
@@ -27831,11 +28288,11 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "Kona coffee farms offer tours and tastings — unique to this region",
+      "Kona coffee farms offer tours and tastings \u2014 unique to this region",
       "Night manta ray snorkeling/diving is a bucket-list experience",
-      "Pu'uhonua o Hōnaunau (Place of Refuge) is a cultural highlight",
+      "Pu'uhonua o H\u014dnaunau (Place of Refuge) is a cultural highlight",
       "Kealakekua Bay (Captain Cook monument) has the best snorkeling",
-      "The Kona coast is much drier than Hilo — bring sunscreen not rain gear"
+      "The Kona coast is much drier than Hilo \u2014 bring sunscreen not rain gear"
     ],
     "packing_nudges": [
       "Light beach clothing",
@@ -27946,7 +28403,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "31-84°F — Slovenian Adriatic",
+      "temp_range": "31-84\u00b0F \u2014 Slovenian Adriatic",
       "humidity": "Moderate (56-74%)",
       "rain": "Year-round; slightly drier summer",
       "wind": "Bora from northeast",
@@ -27982,8 +28439,8 @@
       "Feb"
     ],
     "catches_off_guard": [
-      "Slovenia's only coastal town — surprisingly Mediterranean",
-      "Piran nearby is the real gem — Venetian architecture",
+      "Slovenia's only coastal town \u2014 surprisingly Mediterranean",
+      "Piran nearby is the real gem \u2014 Venetian architecture",
       "Short drive to Postojna Cave and Ljubljana",
       "Istrian cuisine blends Italian and Slavic influences",
       "Wine region (Karst) produces excellent Teran and Malvasia"
@@ -28097,7 +28554,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "75-89°F year-round tropical",
+      "temp_range": "75-89\u00b0F year-round tropical",
       "humidity": "High year-round",
       "rain": "Wettest Oct-Jan; driest Feb-Apr",
       "wind": "Light monsoon winds",
@@ -28137,7 +28594,7 @@
       "Jan"
     ],
     "catches_off_guard": [
-      "Mt. Kinabalu is visible only on clear mornings — afternoons cloud over",
+      "Mt. Kinabalu is visible only on clear mornings \u2014 afternoons cloud over",
       "Island hopping to Tunku Abdul Rahman Park is weather-dependent",
       "Sabah is in a different time zone from Peninsular Malaysia",
       "Monsoon season (Oct-Jan) can bring rough seas",
@@ -28252,7 +28709,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "35-83°F — fjord-like bay setting",
+      "temp_range": "35-83\u00b0F \u2014 fjord-like bay setting",
       "humidity": "Moderate (50-66%)",
       "rain": "Very wet winters; drier Jun-Aug",
       "wind": "Sheltered by mountains; occasional Bura",
@@ -28291,9 +28748,9 @@
     "catches_off_guard": [
       "Bay of Kotor looks like a fjord but is Mediterranean",
       "Fortress climb (1350 steps) rewards with incredible views",
-      "Old town is tiny — gets overwhelmed with cruise visitors",
+      "Old town is tiny \u2014 gets overwhelmed with cruise visitors",
       "Perast and Our Lady of the Rocks are must-see nearby",
-      "One of rainiest spots in Europe — 100+ inches/year in parts"
+      "One of rainiest spots in Europe \u2014 100+ inches/year in parts"
     ],
     "packing_nudges": [
       "Sturdy shoes for fortress climb",
@@ -28404,7 +28861,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "75-91°F year-round tropical",
+      "temp_range": "75-91\u00b0F year-round tropical",
       "humidity": "High year-round (77-82%)",
       "rain": "Two wet seasons; driest Jun-Aug",
       "wind": "Light; monsoon influenced",
@@ -28437,10 +28894,10 @@
     "avoid_months": [],
     "catches_off_guard": [
       "Port Klang is 1.5+ hours from KL city center in traffic",
-      "KL traffic is legendarily bad — plan for delays",
+      "KL traffic is legendarily bad \u2014 plan for delays",
       "Afternoon thunderstorms happen almost daily",
       "The Batu Caves have 272 steps in full sun and heat",
-      "Petronas Towers tickets sell out — pre-book"
+      "Petronas Towers tickets sell out \u2014 pre-book"
     ],
     "packing_nudges": [
       "Light breathable clothing",
@@ -28551,7 +29008,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "38-90°F — hot dry summers",
+      "temp_range": "38-90\u00b0F \u2014 hot dry summers",
       "humidity": "Low to moderate (34-68%)",
       "rain": "Dry May-Sep; wet winters",
       "wind": "Sea breezes moderate summer heat",
@@ -28589,16 +29046,16 @@
       "Aug"
     ],
     "catches_off_guard": [
-      "Ephesus is the #1 attraction — arrive early to beat crowds and heat",
-      "Summer temperatures at Ephesus can reach 100°F with no shade",
-      "Carpet shop tours are aggressive — polite but firm if not interested",
+      "Ephesus is the #1 attraction \u2014 arrive early to beat crowds and heat",
+      "Summer temperatures at Ephesus can reach 100\u00b0F with no shade",
+      "Carpet shop tours are aggressive \u2014 polite but firm if not interested",
       "Ladies Beach is crowded but accessible",
       "House of the Virgin Mary is a short detour from Ephesus"
     ],
     "packing_nudges": [
       "Sturdy walking shoes for Ephesus marble streets",
-      "Hat and sunscreen — no shade at ruins",
-      "Water bottle — essential at Ephesus",
+      "Hat and sunscreen \u2014 no shade at ruins",
+      "Water bottle \u2014 essential at Ephesus",
       "Cash for vendors and leather shops"
     ],
     "hazards": {
@@ -28704,7 +29161,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "30-90°F — inland basin extremes",
+      "temp_range": "30-90\u00b0F \u2014 inland basin extremes",
       "humidity": "Muggy summers; cool dry winters",
       "rain": "Rainy season Jun-Jul; autumn can be wet",
       "wind": "Light; basin geography traps heat",
@@ -28740,14 +29197,14 @@
       "Aug"
     ],
     "catches_off_guard": [
-      "Kyoto basin traps summer heat — hotter than coastal cities",
+      "Kyoto basin traps summer heat \u2014 hotter than coastal cities",
       "Cherry blossom season brings massive crowds to temples",
       "Autumn foliage (mid-Nov) is equally crowded",
       "It's a 75-min train ride from Osaka/Kobe ports",
       "Temple etiquette requires modest dress even in summer heat"
     ],
     "packing_nudges": [
-      "Layers — Kyoto is colder than coast in winter",
+      "Layers \u2014 Kyoto is colder than coast in winter",
       "Rain gear year-round",
       "Breathable clothing for summer",
       "Comfortable walking shoes for temple grounds",
@@ -28755,7 +29212,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "May – Nov (Western Pacific typhoon season)",
+      "hurricane_season": "May \u2013 Nov (Western Pacific typhoon season)",
       "peak_risk_months": [
         "Aug",
         "Sep",
@@ -28861,7 +29318,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "42-73°F — Atlantic Galicia, green and cool",
+      "temp_range": "42-73\u00b0F \u2014 Atlantic Galicia, green and cool",
       "humidity": "High (72-77%)",
       "rain": "Wet year-round; drier Jun-Aug",
       "wind": "Atlantic winds frequent",
@@ -28899,14 +29356,14 @@
       "Feb"
     ],
     "catches_off_guard": [
-      "NOT Mediterranean — this is Atlantic Spain, cool and green",
+      "NOT Mediterranean \u2014 this is Atlantic Spain, cool and green",
       "Tower of Hercules is oldest working lighthouse (Roman)",
       "Seafood here rivals anywhere in the world",
       "Santiago de Compostela day trip is popular",
-      "Rain is common even in summer — carry a jacket"
+      "Rain is common even in summer \u2014 carry a jacket"
     ],
     "packing_nudges": [
-      "Waterproof jacket — essential",
+      "Waterproof jacket \u2014 essential",
       "Comfortable walking shoes",
       "Layers for changeable weather",
       "Appetite for seafood"
@@ -29014,7 +29471,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "37-82°F — gateway to Cinque Terre",
+      "temp_range": "37-82\u00b0F \u2014 gateway to Cinque Terre",
       "humidity": "Moderate (58-73%)",
       "rain": "Wetter than south Med; autumn floods possible",
       "wind": "Generally sheltered by mountains",
@@ -29058,13 +29515,13 @@
     ],
     "catches_off_guard": [
       "Cinque Terre trails REQUIRE advance booking in peak season",
-      "Some trails close after heavy rain — check conditions",
+      "Some trails close after heavy rain \u2014 check conditions",
       "August is overcrowded and hot",
       "Trains between Cinque Terre villages are practical",
-      "Pesto Genovese originated here — try it fresh"
+      "Pesto Genovese originated here \u2014 try it fresh"
     ],
     "packing_nudges": [
-      "Sturdy hiking shoes — trails are steep",
+      "Sturdy hiking shoes \u2014 trails are steep",
       "Sun protection",
       "Train pass for Cinque Terre",
       "Cash for small trattorias"
@@ -29172,7 +29629,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "72-92°F year-round",
+      "temp_range": "72-92\u00b0F year-round",
       "humidity": "Moderate (63-74%)",
       "rain": "Drier Dec-Mar; wetter May-Oct",
       "wind": "Sea breezes; sheltered cove",
@@ -29211,11 +29668,11 @@
       "Sep"
     ],
     "catches_off_guard": [
-      "Royal Caribbean private resort — not representative of Haiti",
+      "Royal Caribbean private resort \u2014 not representative of Haiti",
       "No independent exploration beyond fenced area",
       "Dragon's Breath zipline books fast",
       "Prime beach chairs go early",
-      "All charges go to ship account — no cash needed"
+      "All charges go to ship account \u2014 no cash needed"
     ],
     "packing_nudges": [
       "Reef-safe sunscreen",
@@ -29225,7 +29682,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Sep",
         "Oct"
@@ -29331,7 +29788,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "75-92°F year-round tropical",
+      "temp_range": "75-92\u00b0F year-round tropical",
       "humidity": "High year-round; wettest Sep-Nov",
       "rain": "Two monsoon seasons; driest Dec-Mar",
       "wind": "Light; stronger during monsoon transitions",
@@ -29367,11 +29824,11 @@
       "Oct"
     ],
     "catches_off_guard": [
-      "Langkawi is a duty-free island — shopping is unusually cheap",
-      "Rainy season still has sunny mornings — storms hit afternoons",
+      "Langkawi is a duty-free island \u2014 shopping is unusually cheap",
+      "Rainy season still has sunny mornings \u2014 storms hit afternoons",
       "Eagle feeding tours operate year-round but visibility matters",
       "Cenang Beach gets crowded during Malaysian school holidays",
-      "Mangrove tours are spectacular but buggy — bring repellent"
+      "Mangrove tours are spectacular but buggy \u2014 bring repellent"
     ],
     "packing_nudges": [
       "Light breathable clothing",
@@ -29482,7 +29939,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "55-84°F — volcanic desert island",
+      "temp_range": "55-84\u00b0F \u2014 volcanic desert island",
       "humidity": "Moderate (58-67%)",
       "rain": "Almost none May-Sep; very little overall",
       "wind": "Persistent trade winds",
@@ -29522,14 +29979,14 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "César Manrique's art installations integrated into volcanic landscape",
+      "C\u00e9sar Manrique's art installations integrated into volcanic landscape",
       "Timanfaya National Park volcanic terrain is otherworldly",
       "Wine grown in volcanic pits (La Geria) is unique",
-      "Very windy — Famara Beach is world-class for surfing",
-      "Driest Canary Island — pack water and sun protection"
+      "Very windy \u2014 Famara Beach is world-class for surfing",
+      "Driest Canary Island \u2014 pack water and sun protection"
     ],
     "packing_nudges": [
-      "Sunscreen — intense UV",
+      "Sunscreen \u2014 intense UV",
       "Wind protection for beaches",
       "Sturdy shoes for volcanic trails",
       "Cash for local wines"
@@ -29637,7 +30094,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "66-87°F year-round tropical",
+      "temp_range": "66-87\u00b0F year-round tropical",
       "humidity": "High; drier western side of Viti Levu",
       "rain": "Wet season Nov-Apr; drier than Suva",
       "wind": "Trade winds; drier western exposure",
@@ -29681,7 +30138,7 @@
       "Mar"
     ],
     "catches_off_guard": [
-      "Lautoka is Fiji's Sugar City — sugar cane fields surround it",
+      "Lautoka is Fiji's Sugar City \u2014 sugar cane fields surround it",
       "The western side of Viti Levu is drier than Suva",
       "Denarau Island resorts are nearby for beach excursions",
       "Garden of the Sleeping Giant (orchids) is a popular stop",
@@ -29696,7 +30153,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Nov – Apr (South Pacific cyclone season)",
+      "hurricane_season": "Nov \u2013 Apr (South Pacific cyclone season)",
       "peak_risk_months": [
         "Jan",
         "Feb",
@@ -29802,7 +30259,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "36-68°F — Normandy channel coast",
+      "temp_range": "36-68\u00b0F \u2014 Normandy channel coast",
       "humidity": "High; maritime",
       "rain": "Frequent; slightly drier May-Jul",
       "wind": "Can be strong; Channel exposure",
@@ -29845,9 +30302,9 @@
     "avoid_months": [],
     "catches_off_guard": [
       "Le Havre is the gateway to Paris (2.5 hours by bus/train)",
-      "D-Day beaches are 1-2 hours away — book early for Normandy tours",
+      "D-Day beaches are 1-2 hours away \u2014 book early for Normandy tours",
       "The rebuilt city center is a UNESCO site (post-WWII Auguste Perret design)",
-      "Étretat's dramatic chalk cliffs are 30 min north",
+      "\u00c9tretat's dramatic chalk cliffs are 30 min north",
       "Honfleur is just across the Seine estuary"
     ],
     "packing_nudges": [
@@ -29959,10 +30416,10 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "33-58°F — Shetland subarctic maritime",
+      "temp_range": "33-58\u00b0F \u2014 Shetland subarctic maritime",
       "humidity": "Very high",
       "rain": "Very frequent year-round",
-      "wind": "Extremely windy — exposed North Sea/Atlantic",
+      "wind": "Extremely windy \u2014 exposed North Sea/Atlantic",
       "daylight": "5.5-19 hours (simmer dim in June)"
     },
     "best_months_for": {
@@ -29995,17 +30452,17 @@
     "avoid_months": [],
     "catches_off_guard": [
       "Shetland is closer to Norway than to London",
-      "Puffins nest on the cliffs May-July — spectacular colonies",
+      "Puffins nest on the cliffs May-July \u2014 spectacular colonies",
       "Up Helly Aa (January fire festival) is a unique Viking tradition",
-      "Fair Isle knitwear is world-famous — buy it at source",
+      "Fair Isle knitwear is world-famous \u2014 buy it at source",
       "The simmer dim (midsummer near-daylight) is magical"
     ],
     "packing_nudges": [
       "Warm windproof waterproof layers",
-      "Warm hat — wind is relentless",
+      "Warm hat \u2014 wind is relentless",
       "Sturdy waterproof shoes",
       "Binoculars for puffins and seabirds",
-      "Multiple layers — the wind is brutal"
+      "Multiple layers \u2014 the wind is brutal"
     ],
     "hazards": {
       "hurricane_zone": false
@@ -30109,7 +30566,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "61-84°F year-round tropical",
+      "temp_range": "61-84\u00b0F year-round tropical",
       "humidity": "Moderate to high",
       "rain": "Wetter Dec-Apr; drier Jun-Sep",
       "wind": "Trade winds",
@@ -30149,7 +30606,7 @@
       "Lifou's Jinek Bay is one of the most beautiful tender anchorages",
       "Loyalty Islands Kanak culture is authentic and welcoming",
       "The cave swimming holes are spectacular",
-      "Infrastructure is minimal — this is a natural paradise",
+      "Infrastructure is minimal \u2014 this is a natural paradise",
       "Vanilla plantations are a unique local industry"
     ],
     "packing_nudges": [
@@ -30157,11 +30614,11 @@
       "Reef-safe sunscreen",
       "Water shoes for coral beaches",
       "Snorkel gear",
-      "Cash — limited facilities"
+      "Cash \u2014 limited facilities"
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Nov – Apr (South Pacific cyclone season)",
+      "hurricane_season": "Nov \u2013 Apr (South Pacific cyclone season)",
       "peak_risk_months": [
         "Jan",
         "Feb",
@@ -30267,7 +30724,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "44-94°F — one of hottest Med islands",
+      "temp_range": "44-94\u00b0F \u2014 one of hottest Med islands",
       "humidity": "Low to moderate (48-65%)",
       "rain": "Dry May-Sep; wet winters",
       "wind": "Generally light; sea breezes",
@@ -30313,14 +30770,14 @@
     ],
     "catches_off_guard": [
       "Kourion archaeological site has spectacular clifftop theatre",
-      "Summer heat is extreme — 95°F+ common",
+      "Summer heat is extreme \u2014 95\u00b0F+ common",
       "Commandaria wine is world's oldest named wine",
       "Limassol castle has good museum",
       "Beach-to-mountain drive is only 45 minutes"
     ],
     "packing_nudges": [
       "Heavy sunscreen for summer",
-      "Water bottle — dehydration risk",
+      "Water bottle \u2014 dehydration risk",
       "Light breathable clothing",
       "Comfortable shoes for ruins"
     ],
@@ -30427,7 +30884,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "46-81°F — mild Atlantic climate",
+      "temp_range": "46-81\u00b0F \u2014 mild Atlantic climate",
       "humidity": "Moderate (53-80%)",
       "rain": "Wet Oct-Mar; very dry summers",
       "wind": "Atlantic breezes; northerly Nortada in summer",
@@ -30471,14 +30928,14 @@
       "Aug"
     ],
     "catches_off_guard": [
-      "Hills are STEEP — Alfama and Bairro Alto are a workout",
-      "Tram 28 is famous but packed — consider walking instead",
-      "August locals flee the city — some shops close",
+      "Hills are STEEP \u2014 Alfama and Bairro Alto are a workout",
+      "Tram 28 is famous but packed \u2014 consider walking instead",
+      "August locals flee the city \u2014 some shops close",
       "Atlantic-facing beaches have cold water even in summer",
-      "Custard tarts (pastéis de nata) vary hugely in quality"
+      "Custard tarts (past\u00e9is de nata) vary hugely in quality"
     ],
     "packing_nudges": [
-      "Comfortable walking shoes — cobblestones everywhere",
+      "Comfortable walking shoes \u2014 cobblestones everywhere",
       "Light layers for morning fog",
       "Sunscreen for summer",
       "Cash for smaller restaurants"
@@ -30586,7 +31043,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "34-67°F — Beatles city, maritime",
+      "temp_range": "34-67\u00b0F \u2014 Beatles city, maritime",
       "humidity": "High (71-83%)",
       "rain": "Year-round; slightly drier spring",
       "wind": "Irish Sea influence",
@@ -30621,7 +31078,7 @@
       "Albert Dock is UNESCO and home to Tate Liverpool, Beatles Story",
       "Cavern Club (Beatles venue) is rebuilt but atmospheric",
       "Two cathedrals represent different architectural extremes",
-      "Ferry Cross the Mersey is cliché but pleasant",
+      "Ferry Cross the Mersey is clich\u00e9 but pleasant",
       "Liverpool ONE shopping is impressive modern development"
     ],
     "packing_nudges": [
@@ -30733,7 +31190,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "38-84°F — Tuscany gateway",
+      "temp_range": "38-84\u00b0F \u2014 Tuscany gateway",
       "humidity": "Moderate (52-73%)",
       "rain": "Wetter winters; dry summers",
       "wind": "Sea breezes; occasional libeccio",
@@ -30772,15 +31229,15 @@
     ],
     "catches_off_guard": [
       "Gateway to Florence (1.5hr) and Pisa (20min)",
-      "Plan excursion in advance — independent transport takes time",
-      "Florence is overwhelming — focus on 2-3 highlights",
+      "Plan excursion in advance \u2014 independent transport takes time",
+      "Florence is overwhelming \u2014 focus on 2-3 highlights",
       "Livorno itself has excellent seafood (cacciucco)",
       "Bolgheri wine region nearby is less touristy than Chianti"
     ],
     "packing_nudges": [
       "Comfortable walking shoes for Florence",
       "Sun protection for summer",
-      "Layers — mornings can be cool",
+      "Layers \u2014 mornings can be cool",
       "Museum reservation confirmation printouts"
     ],
     "hazards": {
@@ -30886,7 +31343,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "70-87°F year-round tropical",
+      "temp_range": "70-87\u00b0F year-round tropical",
       "humidity": "Lower dry season; higher wet",
       "rain": "Wet season Nov-Mar; dry Apr-Oct",
       "wind": "Trade winds Jul-Aug for surfing",
@@ -30929,11 +31386,11 @@
       "Feb"
     ],
     "catches_off_guard": [
-      "Lombok is less developed than Bali — facilities are basic in places",
-      "Gili Islands are accessible only by boat — sea conditions matter",
+      "Lombok is less developed than Bali \u2014 facilities are basic in places",
+      "Gili Islands are accessible only by boat \u2014 sea conditions matter",
       "Mt. Rinjani trek requires permits and good weather",
       "Dry season is significantly more pleasant than wet",
-      "Local customs are more conservative than Bali — dress modestly"
+      "Local customs are more conservative than Bali \u2014 dress modestly"
     ],
     "packing_nudges": [
       "Light breathable clothing",
@@ -31044,8 +31501,8 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "68-84°F; warm sunny Mediterranean climate, rarely rains",
-      "humidity": "Moderate (60-68%) — comfortable most of year",
+      "temp_range": "68-84\u00b0F; warm sunny Mediterranean climate, rarely rains",
+      "humidity": "Moderate (60-68%) \u2014 comfortable most of year",
       "rain": "Virtually none May-Oct; light rain Dec-Mar",
       "wind": "Light breezes; Santa Ana winds in fall can be hot and dry",
       "daylight": "10-14 hours; abundant sunshine year-round"
@@ -31085,12 +31542,12 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "Traffic is legendarily bad — allow 2-3x expected time for anything",
+      "Traffic is legendarily bad \u2014 allow 2-3x expected time for anything",
       "Marine layer (clouds) at coast can persist while inland is sunny/hot",
-      "Ocean water is cold (60-68°F) — not warm beach swimming",
+      "Ocean water is cold (60-68\u00b0F) \u2014 not warm beach swimming",
       "Port (San Pedro/Long Beach) is far from Hollywood/downtown (30-90 min)",
       "Air quality can be poor (smog) especially summer and fall",
-      "Distances are huge — LA is massive and spread out"
+      "Distances are huge \u2014 LA is massive and spread out"
     ],
     "packing_nudges": [
       "Light layers (coastal cool, inland hot)",
@@ -31203,7 +31660,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "64-87°F tropical coastal",
+      "temp_range": "64-87\u00b0F tropical coastal",
       "humidity": "High year-round",
       "rain": "Wet season Oct-Apr; dry May-Sep",
       "wind": "Light; Benguela Current moderates coast",
@@ -31353,7 +31810,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "32-72°F temperate Canterbury climate",
+      "temp_range": "32-72\u00b0F temperate Canterbury climate",
       "humidity": "Moderate",
       "rain": "Evenly distributed; moderate",
       "wind": "Nor'wester can be strong",
@@ -31385,7 +31842,7 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "Lyttelton is Christchurch's port village — small but charming",
+      "Lyttelton is Christchurch's port village \u2014 small but charming",
       "The tunnel to Christchurch takes 10 minutes",
       "Saturday farmers market is excellent",
       "The harbor provides shelter but the port area can be windy",
@@ -31500,7 +31957,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "46-87°F — Costa del Sol lives up to its name",
+      "temp_range": "46-87\u00b0F \u2014 Costa del Sol lives up to its name",
       "humidity": "Low to moderate (44-67%)",
       "rain": "Dry May-Sep; mild wet winters",
       "wind": "Generally calm; sea breezes",
@@ -31542,11 +31999,11 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "300+ sunny days per year — sunburn sneaks up",
+      "300+ sunny days per year \u2014 sunburn sneaks up",
       "Picasso Museum is small but excellent",
       "Caminito del Rey hike requires advance booking",
       "Summer beach crowds in old town area are intense",
-      "Fried fish (pescaíto) is the local specialty"
+      "Fried fish (pesca\u00edto) is the local specialty"
     ],
     "packing_nudges": [
       "Sunscreen year-round",
@@ -31657,7 +32114,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "77-88°F year-round tropical",
+      "temp_range": "77-88\u00b0F year-round tropical",
       "humidity": "High year-round (76-80%)",
       "rain": "Wet season May-Nov; dry Dec-Apr",
       "wind": "Northeast monsoon (dry); southwest monsoon (wet)",
@@ -31701,9 +32158,9 @@
       "Jul"
     ],
     "catches_off_guard": [
-      "The Maldives is barely above sea level — rising tides are a reality",
+      "The Maldives is barely above sea level \u2014 rising tides are a reality",
       "Southwest monsoon brings reduced visibility for diving",
-      "Many resorts are overwater — check sea conditions",
+      "Many resorts are overwater \u2014 check sea conditions",
       "Male city itself is extremely crowded and not particularly scenic",
       "Alcohol is only available at resorts, not in Male"
     ],
@@ -31816,7 +32273,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "74-91°F year-round equatorial",
+      "temp_range": "74-91\u00b0F year-round equatorial",
       "humidity": "Very high year-round; Amazon rainforest",
       "rain": "Wet season Dec-May; drier Jun-Nov",
       "wind": "Light",
@@ -31854,9 +32311,9 @@
     "avoid_months": [],
     "catches_off_guard": [
       "The Meeting of the Waters (Rio Negro + Amazon) is visible year-round",
-      "River levels change 30+ feet between seasons — drastically different landscape",
+      "River levels change 30+ feet between seasons \u2014 drastically different landscape",
       "Pink river dolphins are more visible in low-water season",
-      "Mosquitoes and insects are relentless — long sleeves help",
+      "Mosquitoes and insects are relentless \u2014 long sleeves help",
       "The Opera House (Teatro Amazonas) is a stunning cultural landmark"
     ],
     "packing_nudges": [
@@ -31968,7 +32425,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "72-93°F year-round tropical",
+      "temp_range": "72-93\u00b0F year-round tropical",
       "humidity": "High; extreme in wet season",
       "rain": "Wet season Jun-Nov (typhoon season); dry Dec-May",
       "wind": "Typhoon exposure Jun-Nov",
@@ -32008,8 +32465,8 @@
       "Oct"
     ],
     "catches_off_guard": [
-      "Metro Manila traffic is catastrophic — short distances take hours",
-      "Typhoons frequently hit Luzon Jul-Nov — ships may skip the port",
+      "Metro Manila traffic is catastrophic \u2014 short distances take hours",
+      "Typhoons frequently hit Luzon Jul-Nov \u2014 ships may skip the port",
       "Wet season flooding paralyzes the city regularly",
       "Intramuros (historic district) has limited shade",
       "Jeepney rides are an experience but not air-conditioned"
@@ -32023,7 +32480,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "May – Nov (Western Pacific typhoon season)",
+      "hurricane_season": "May \u2013 Nov (Western Pacific typhoon season)",
       "peak_risk_months": [
         "Aug",
         "Sep",
@@ -32129,7 +32586,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "68-85°F year-round warm coast",
+      "temp_range": "68-85\u00b0F year-round warm coast",
       "humidity": "Moderate to high",
       "rain": "Wet season Dec-Apr; very dry Jun-Nov",
       "wind": "Cool Humboldt Current influence",
@@ -32168,11 +32625,11 @@
       "Mar"
     ],
     "catches_off_guard": [
-      "Humpback whales migrate through Jun-Oct — spectacular viewing",
+      "Humpback whales migrate through Jun-Oct \u2014 spectacular viewing",
       "Montecristi (nearby) is the real origin of 'Panama' hats",
-      "Fresh ceviche is a must — Ecuador's is distinct from Peru's",
+      "Fresh ceviche is a must \u2014 Ecuador's is distinct from Peru's",
       "The Humboldt Current keeps coastal temps moderate",
-      "Manta was severely damaged in the 2016 earthquake — rebuilt"
+      "Manta was severely damaged in the 2016 earthquake \u2014 rebuilt"
     ],
     "packing_nudges": [
       "Light breathable clothing",
@@ -32283,7 +32740,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "67-90°F year-round tropical",
+      "temp_range": "67-90\u00b0F year-round tropical",
       "humidity": "Low dry; high wet season",
       "rain": "Dry Nov-May; very wet Jun-Oct",
       "wind": "Light coastal breezes",
@@ -32322,9 +32779,9 @@
       "Sep"
     ],
     "catches_off_guard": [
-      "Manzanillo is Mexico's sailfish capital — world-class sport fishing",
+      "Manzanillo is Mexico's sailfish capital \u2014 world-class sport fishing",
       "The twin bays create a dramatic setting",
-      "Less touristy than Puerto Vallarta or Cabo — more authentic",
+      "Less touristy than Puerto Vallarta or Cabo \u2014 more authentic",
       "Fresh seafood is outstanding and inexpensive",
       "The main beach (Playa de Santiago) is walkable from the port"
     ],
@@ -32337,7 +32794,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "May 15 – Nov 30 (East Pacific)",
+      "hurricane_season": "May 15 \u2013 Nov 30 (East Pacific)",
       "peak_risk_months": [
         "Aug",
         "Sep",
@@ -32443,7 +32900,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "55-86°F subtropical",
+      "temp_range": "55-86\u00b0F subtropical",
       "humidity": "Higher summer; moderate winter",
       "rain": "Wet summer (Oct-Mar); dry winter (May-Sep)",
       "wind": "Light coastal breezes",
@@ -32500,7 +32957,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Nov – Apr (Indian Ocean cyclone season)",
+      "hurricane_season": "Nov \u2013 Apr (Indian Ocean cyclone season)",
       "peak_risk_months": [
         "Jan",
         "Feb",
@@ -32606,8 +33063,8 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "54-84°F; hot dry summers, mild wet winters",
-      "humidity": "Low to Moderate (57-69%) — Mediterranean with Mistral influence",
+      "temp_range": "54-84\u00b0F; hot dry summers, mild wet winters",
+      "humidity": "Low to Moderate (57-69%) \u2014 Mediterranean with Mistral influence",
       "rain": "Wettest Oct-Nov; summers very dry",
       "wind": "Mistral winds can be intense (40+ mph), especially winter/spring",
       "daylight": "9-15 hours; long summer days for exploring Provence"
@@ -32653,8 +33110,8 @@
     "catches_off_guard": [
       "Mistral winds can be brutally strong and cold even in summer",
       "August is extremely hot and many businesses close for vacation",
-      "Port area is industrial — shuttle required to reach city center",
-      "City has reputation for petty crime — stay alert",
+      "Port area is industrial \u2014 shuttle required to reach city center",
+      "City has reputation for petty crime \u2014 stay alert",
       "Provence lavender fields peak mid-Jun to mid-Jul only",
       "Public transport strikes are common in France"
     ],
@@ -32664,7 +33121,7 @@
       "Crossbody anti-theft bag",
       "Comfortable walking shoes for Old Port cobblestones",
       "Sunglasses that fit snugly",
-      "Layers (Mistral can make 70°F feel like 50°F)"
+      "Layers (Mistral can make 70\u00b0F feel like 50\u00b0F)"
     ],
     "hazards": {
       "hurricane_zone": false,
@@ -32769,7 +33226,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "25-79°F — temperate island",
+      "temp_range": "25-79\u00b0F \u2014 temperate island",
       "humidity": "Moderate",
       "rain": "Distributed; drier summer",
       "wind": "Strong; exposed island location",
@@ -32810,7 +33267,7 @@
       "Mar"
     ],
     "catches_off_guard": [
-      "The island has a unique character — each town is distinct",
+      "The island has a unique character \u2014 each town is distinct",
       "Edgartown has the most historic whaling captain homes",
       "Aquinnah Cliffs are a stunning geological feature",
       "The ferry from the mainland is iconic but not for cruise visitors",
@@ -32925,7 +33382,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "71-88°F year-round",
+      "temp_range": "71-88\u00b0F year-round",
       "humidity": "High (73-81%)",
       "rain": "Wet Jun-Nov; mountains amplify",
       "wind": "Trades; calmer west coast",
@@ -32970,25 +33427,25 @@
     ],
     "catches_off_guard": [
       "Fort-de-France is a real working city",
-      "Mont Pelée 1902 eruption ruins at St. Pierre",
-      "French cuisine exceptional — reserve ahead",
+      "Mont Pel\u00e9e 1902 eruption ruins at St. Pierre",
+      "French cuisine exceptional \u2014 reserve ahead",
       "Anse Noire and Anse Dufour hidden gems",
-      "Rum distilleries (Clément, Trois Rivières) world-class"
+      "Rum distilleries (Cl\u00e9ment, Trois Rivi\u00e8res) world-class"
     ],
     "packing_nudges": [
       "Rain jacket for mountains",
       "Walking shoes for St. Pierre",
       "Reef-safe sunscreen",
-      "French phrasebook — English limited"
+      "French phrasebook \u2014 English limited"
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Sep",
         "Oct"
       ],
-      "note": "Volcanic island; Pelée is monitored"
+      "note": "Volcanic island; Pel\u00e9e is monitored"
     },
     "cruise_seasons": {
       "high": [
@@ -33089,7 +33546,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "63-88°F year-round tropical",
+      "temp_range": "63-88\u00b0F year-round tropical",
       "humidity": "Low to moderate; varies by coast",
       "rain": "Drier south/west shores; wetter north/east",
       "wind": "Trade winds; calmer in fall (Kona weather)",
@@ -33138,16 +33595,16 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "Haleakalā sunrise requires advance reservations and warm clothing (30°F at summit)",
+      "Haleakal\u0101 sunrise requires advance reservations and warm clothing (30\u00b0F at summit)",
       "Road to Hana is stunning but takes a full day and can cause carsickness",
-      "Whale watching (Dec-Apr) is world-class — humpbacks breed here",
+      "Whale watching (Dec-Apr) is world-class \u2014 humpbacks breed here",
       "Molokini Crater snorkeling is best in morning calm",
       "Ka'anapali and Wailea have the best beaches and driest weather"
     ],
     "packing_nudges": [
       "Light beach clothing",
       "Reef-safe sunscreen (law)",
-      "Warm layers for Haleakalā",
+      "Warm layers for Haleakal\u0101",
       "Motion sickness meds for Road to Hana",
       "Water shoes for rocky beach entries"
     ],
@@ -33253,7 +33710,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "63-86°F — warm summers, mild winters",
+      "temp_range": "63-86\u00b0F \u2014 warm summers, mild winters",
       "humidity": "Higher in summer (Dec-Mar)",
       "rain": "Wetter Dec-Mar; drier Jun-Sep",
       "wind": "Southeast trade winds year-round; stronger Jun-Sep",
@@ -33300,7 +33757,7 @@
     ],
     "catches_off_guard": [
       "Cyclone season (Jan-Mar) can bring destructive storms",
-      "Southern Hemisphere seasons are reversed — Dec-Feb is summer",
+      "Southern Hemisphere seasons are reversed \u2014 Dec-Feb is summer",
       "Southeast trade winds make the east coast cooler and rougher",
       "The dodo is extinct but featured everywhere as a symbol",
       "Sugar cane harvest (Jul-Nov) makes inland areas less scenic"
@@ -33314,7 +33771,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Nov – Apr (Indian Ocean cyclone season)",
+      "hurricane_season": "Nov \u2013 Apr (Indian Ocean cyclone season)",
       "peak_risk_months": [
         "Jan",
         "Feb",
@@ -33420,7 +33877,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "58-91°F tropical Pacific coast",
+      "temp_range": "58-91\u00b0F tropical Pacific coast",
       "humidity": "Low dry season; very high wet",
       "rain": "Dry Nov-May; very wet Jun-Oct",
       "wind": "Light to moderate",
@@ -33458,9 +33915,9 @@
       "Sep"
     ],
     "catches_off_guard": [
-      "Mazatlán has the longest malecón in Mexico",
-      "Historic Centro Histórico has been beautifully restored",
-      "Carnival in Mazatlán is one of Mexico's largest",
+      "Mazatl\u00e1n has the longest malec\u00f3n in Mexico",
+      "Historic Centro Hist\u00f3rico has been beautifully restored",
+      "Carnival in Mazatl\u00e1n is one of Mexico's largest",
       "Fresh seafood (especially shrimp) is outstanding",
       "The Cliff Divers at El Clavadista are a traditional spectacle"
     ],
@@ -33473,7 +33930,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "May 15 – Nov 30 (East Pacific)",
+      "hurricane_season": "May 15 \u2013 Nov 30 (East Pacific)",
       "peak_risk_months": [
         "Aug",
         "Sep",
@@ -33579,7 +34036,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "42-78°F — temperate with famous changeability",
+      "temp_range": "42-78\u00b0F \u2014 temperate with famous changeability",
       "humidity": "Low to moderate",
       "rain": "Distributed year-round; consistent drizzle",
       "wind": "Can be strong and persistent",
@@ -33622,12 +34079,12 @@
     "catches_off_guard": [
       "Four seasons in one day is a real Melbourne phenomenon",
       "The Great Ocean Road is spectacular but can be foggy and cold",
-      "Laneways and arcades are the real Melbourne — great for any weather",
+      "Laneways and arcades are the real Melbourne \u2014 great for any weather",
       "Australian Rules Football (Mar-Sep) is a unique cultural experience",
-      "Tram network is free in the CBD — use it"
+      "Tram network is free in the CBD \u2014 use it"
     ],
     "packing_nudges": [
-      "Layers essential — weather changes rapidly",
+      "Layers essential \u2014 weather changes rapidly",
       "Windproof jacket",
       "Comfortable walking shoes",
       "Light rain jacket year-round",
@@ -33735,7 +34192,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "45-87°F — strait-side location",
+      "temp_range": "45-87\u00b0F \u2014 strait-side location",
       "humidity": "Moderate (47-73%)",
       "rain": "Dry summers; wet winters",
       "wind": "Strong currents in Strait of Messina",
@@ -33771,7 +34228,7 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "Gateway to Taormina — that's where most visitors head",
+      "Gateway to Taormina \u2014 that's where most visitors head",
       "Astronomical clock on cathedral is worth the noon show",
       "Strait of Messina has powerful currents",
       "1908 earthquake/tsunami destroyed 90% of the city",
@@ -33886,8 +34343,8 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "77-91°F; hot and humid year-round, tropical climate",
-      "humidity": "High (68-78%) — oppressive in summer",
+      "temp_range": "77-91\u00b0F; hot and humid year-round, tropical climate",
+      "humidity": "High (68-78%) \u2014 oppressive in summer",
       "rain": "Wet season Jun-Oct with daily afternoon thunderstorms",
       "wind": "Light breezes; stronger during hurricane season",
       "daylight": "10-14 hours; consistent year-round"
@@ -33931,11 +34388,11 @@
     ],
     "catches_off_guard": [
       "Summer afternoon thunderstorms are daily and intense (lightning danger)",
-      "Humidity makes 90°F feel like 105°F+ — heat exhaustion is common",
-      "Hurricane season is serious — ships may cancel/reroute Sep-Oct",
-      "Traffic is terrible — allow extra time for port return",
-      "South Beach is a long way from cruise port (€€ Uber/taxi)",
-      "Air conditioning is Arctic indoors — bring a light layer"
+      "Humidity makes 90\u00b0F feel like 105\u00b0F+ \u2014 heat exhaustion is common",
+      "Hurricane season is serious \u2014 ships may cancel/reroute Sep-Oct",
+      "Traffic is terrible \u2014 allow extra time for port return",
+      "South Beach is a long way from cruise port (\u20ac\u20ac Uber/taxi)",
+      "Air conditioning is Arctic indoors \u2014 bring a light layer"
     ],
     "packing_nudges": [
       "Light breathable clothing (cotton traps sweat)",
@@ -33947,7 +34404,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Aug",
         "Sep",
@@ -34054,8 +34511,8 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "30-64°F — spectacular fjord",
-      "humidity": "Very high — extremely wet climate",
+      "temp_range": "30-64\u00b0F \u2014 spectacular fjord",
+      "humidity": "Very high \u2014 extremely wet climate",
       "rain": "Among the wettest places on Earth (180+ inches/year)",
       "wind": "Calm within the sound usually",
       "daylight": "8.5-16 hours (Southern Hemisphere)"
@@ -34091,14 +34548,14 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "Milford gets 180+ inches of rain annually — rain is almost certain",
-      "Paradoxically, rain creates the best scenery — hundreds of waterfalls",
+      "Milford gets 180+ inches of rain annually \u2014 rain is almost certain",
+      "Paradoxically, rain creates the best scenery \u2014 hundreds of waterfalls",
       "Mitre Peak is iconic and photogenic in any weather",
-      "Sandflies are relentless — bring strong repellent",
+      "Sandflies are relentless \u2014 bring strong repellent",
       "The drive from Queenstown is spectacular but takes 4+ hours"
     ],
     "packing_nudges": [
-      "Full waterproof gear — jacket and pants",
+      "Full waterproof gear \u2014 jacket and pants",
       "Warm layers underneath",
       "Waterproof boots or shoes",
       "Insect repellent for sandflies",
@@ -34206,9 +34663,9 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "65-85°F year-round mild",
+      "temp_range": "65-85\u00b0F year-round mild",
       "humidity": "Low to moderate; Saharan dust possible",
-      "rain": "Almost none — one of driest archipelagos",
+      "rain": "Almost none \u2014 one of driest archipelagos",
       "wind": "Trade winds can be strong; Saharan dust (Harmattan)",
       "daylight": "11-13 hours seasonal"
     },
@@ -34246,10 +34703,10 @@
     "avoid_months": [],
     "catches_off_guard": [
       "Cape Verde has a unique Creole culture blending Portuguese and African",
-      "Mindelo is the cultural capital — live music is everywhere",
+      "Mindelo is the cultural capital \u2014 live music is everywhere",
       "Saharan dust (Bruma Seca) can obscure views Nov-Mar",
-      "Water is scarce — conservation is important",
-      "The port is very walkable — most attractions are nearby"
+      "Water is scarce \u2014 conservation is important",
+      "The port is very walkable \u2014 most attractions are nearby"
     ],
     "packing_nudges": [
       "Light breathable clothing",
@@ -34279,6 +34736,157 @@
         "Jul",
         "Aug",
         "Sep"
+      ]
+    }
+  },
+  "misty-fjords": {
+    "tier": 1,
+    "timezone": "America/Anchorage",
+    "_source": "No weather station in the monument. Monthly averages copied from the Ketchikan entry already in this file (nearest station, ~40 miles). Label the numbers as Ketchikan normals, not monument-interior readings.",
+    "monthly_averages": {
+      "jan": {
+        "high_f": 38,
+        "low_f": 29,
+        "rain_days": 18,
+        "humidity": 78
+      },
+      "feb": {
+        "high_f": 39,
+        "low_f": 30,
+        "rain_days": 16,
+        "humidity": 76
+      },
+      "mar": {
+        "high_f": 42,
+        "low_f": 31,
+        "rain_days": 17,
+        "humidity": 74
+      },
+      "apr": {
+        "high_f": 49,
+        "low_f": 35,
+        "rain_days": 17,
+        "humidity": 74
+      },
+      "may": {
+        "high_f": 55,
+        "low_f": 41,
+        "rain_days": 16,
+        "humidity": 74
+      },
+      "jun": {
+        "high_f": 61,
+        "low_f": 47,
+        "rain_days": 15,
+        "humidity": 76
+      },
+      "jul": {
+        "high_f": 64,
+        "low_f": 51,
+        "rain_days": 14,
+        "humidity": 79
+      },
+      "aug": {
+        "high_f": 63,
+        "low_f": 51,
+        "rain_days": 15,
+        "humidity": 81
+      },
+      "sep": {
+        "high_f": 57,
+        "low_f": 46,
+        "rain_days": 19,
+        "humidity": 82
+      },
+      "oct": {
+        "high_f": 49,
+        "low_f": 39,
+        "rain_days": 22,
+        "humidity": 82
+      },
+      "nov": {
+        "high_f": 42,
+        "low_f": 33,
+        "rain_days": 20,
+        "humidity": 80
+      },
+      "dec": {
+        "high_f": 38,
+        "low_f": 30,
+        "rain_days": 20,
+        "humidity": 79
+      }
+    },
+    "at_a_glance": {
+      "temp_range": "29-64\u00b0F \u2014 Ketchikan normals; fjord walls run cooler",
+      "humidity": "Very high",
+      "rain": "Rainforest; 140+ in/year at Ketchikan",
+      "wind": "Fjord channeling; waterfalls blow sideways",
+      "daylight": "7-17.5 hours (seasonal)"
+    },
+    "best_months_for": {
+      "scenic_cruising": [
+        "May",
+        "Jun",
+        "Jul",
+        "Aug",
+        "Sep"
+      ],
+      "floatplane": [
+        "Jun",
+        "Jul",
+        "Aug"
+      ],
+      "waterfalls": [
+        "May",
+        "Jun",
+        "Jul"
+      ],
+      "low_crowds": [
+        "May",
+        "Sep"
+      ]
+    },
+    "avoid_months": [
+      "Nov",
+      "Dec",
+      "Jan",
+      "Feb",
+      "Mar"
+    ],
+    "catches_off_guard": [
+      "Most guests see this from a floatplane or small boat out of Ketchikan, not a dock",
+      "Cloud sits in the granite; a clear day is the exception",
+      "The monument is wilderness \u2014 no services",
+      "Ketchikan rain numbers apply; the fjord is not drier",
+      "Floatplane seats book early in July"
+    ],
+    "packing_nudges": [
+      "The same waterproof kit as Ketchikan",
+      "Warm layer for an open-floatplane door",
+      "Camera with a strap"
+    ],
+    "hazards": {
+      "hurricane_zone": false
+    },
+    "cruise_seasons": {
+      "high": [
+        "Jun",
+        "Jul",
+        "Aug"
+      ],
+      "transitional": [
+        "May",
+        "Sep"
+      ],
+      "low": [
+        "Oct",
+        "Nov",
+        "Dec",
+        "Jan",
+        "Feb",
+        "Mar",
+        "Apr"
       ]
     }
   },
@@ -34360,7 +34968,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "40-91°F — Gulf Coast subtropical",
+      "temp_range": "40-91\u00b0F \u2014 Gulf Coast subtropical",
       "humidity": "Moderate to high; humid summers",
       "rain": "Summer thunderstorms; drier fall",
       "wind": "Light; Gulf breezes",
@@ -34392,11 +35000,11 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "Mobile claims the original Mardi Gras — older than New Orleans'",
+      "Mobile claims the original Mardi Gras \u2014 older than New Orleans'",
       "The USS Alabama battleship memorial is a top attraction",
       "Bellingrath Gardens are spectacular year-round",
       "The historic downtown is walkable and underrated",
-      "Gulf seafood is outstanding — try the oysters"
+      "Gulf seafood is outstanding \u2014 try the oysters"
     ],
     "packing_nudges": [
       "Light layers for spring/fall",
@@ -34407,7 +35015,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Sep",
         "Oct"
@@ -34512,7 +35120,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "69-88°F year-round tropical",
+      "temp_range": "69-88\u00b0F year-round tropical",
       "humidity": "High year-round; peak Apr-May",
       "rain": "Long rains Apr-Jun; short rains Oct-Nov",
       "wind": "Monsoon influenced; calmer Dec-Mar",
@@ -34556,7 +35164,7 @@
       "May"
     ],
     "catches_off_guard": [
-      "Combine a cruise stop with a safari — Tsavo is 3 hours away",
+      "Combine a cruise stop with a safari \u2014 Tsavo is 3 hours away",
       "Long rains (Apr-Jun) make roads muddy and some areas inaccessible",
       "Mombasa Old Town is a UNESCO heritage site worth walking",
       "Diani Beach (south) is spectacular but 1+ hour drive",
@@ -34671,7 +35279,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "43-82°F — glamorous Riviera climate",
+      "temp_range": "43-82\u00b0F \u2014 glamorous Riviera climate",
       "humidity": "Moderate (55-70%)",
       "rain": "Mild year-round; wettest autumn",
       "wind": "Occasional Mistral",
@@ -34710,17 +35318,17 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "World's second-smallest country — walkable in hours",
+      "World's second-smallest country \u2014 walkable in hours",
       "Casino Monte Carlo requires jacket and no sneakers",
       "F1 Grand Prix (May) books out the entire principality",
-      "Everything is expensive — budget accordingly",
+      "Everything is expensive \u2014 budget accordingly",
       "Prince's Palace changing of guard at 11:55 daily"
     ],
     "packing_nudges": [
       "Smart casual for casinos and restaurants",
       "Comfortable shoes for steep terrain",
       "Sunscreen for Riviera sun",
-      "Significant cash — many places prefer it"
+      "Significant cash \u2014 many places prefer it"
     ],
     "hazards": {
       "hurricane_zone": false,
@@ -34825,7 +35433,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "71-89°F year-round",
+      "temp_range": "71-89\u00b0F year-round",
       "humidity": "Moderate (70-78%)",
       "rain": "Drier Dec-Apr; wet May-Jun and Sep-Oct",
       "wind": "Trades and sea breezes",
@@ -34877,7 +35485,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Sep",
         "Oct"
@@ -34983,7 +35591,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "41-83°F — four seasons (Southern Hemisphere)",
+      "temp_range": "41-83\u00b0F \u2014 four seasons (Southern Hemisphere)",
       "humidity": "Moderate year-round",
       "rain": "Evenly distributed; slightly drier winter",
       "wind": "Pampero cold fronts; river breezes",
@@ -35024,8 +35632,8 @@
       "Montevideo has a more relaxed pace than Buenos Aires",
       "Ciudad Vieja (Old City) is walkable and full of art deco architecture",
       "Mercado del Puerto is the must-visit food market",
-      "Carnival (Feb) is a major event — different from Brazil's",
-      "Mate tea is a social ritual — you'll see it everywhere"
+      "Carnival (Feb) is a major event \u2014 different from Brazil's",
+      "Mate tea is a social ritual \u2014 you'll see it everywhere"
     ],
     "packing_nudges": [
       "Light layers for spring/fall",
@@ -35136,7 +35744,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "8-79°F — extreme four seasons",
+      "temp_range": "8-79\u00b0F \u2014 extreme four seasons",
       "humidity": "Moderate; variable",
       "rain": "Distributed; snow Nov-Apr",
       "wind": "Strong; river corridor effects",
@@ -35176,15 +35784,15 @@
       "Feb"
     ],
     "catches_off_guard": [
-      "Montreal is genuinely bilingual — French and English spoken everywhere",
+      "Montreal is genuinely bilingual \u2014 French and English spoken everywhere",
       "Old Montreal is charming with cobblestone streets and historic buildings",
-      "The food scene rivals any North American city — especially smoked meat and bagels",
-      "Underground City (RÉSO) connects 20+ miles of shops — great for bad weather",
+      "The food scene rivals any North American city \u2014 especially smoked meat and bagels",
+      "Underground City (R\u00c9SO) connects 20+ miles of shops \u2014 great for bad weather",
       "Mount Royal park offers city panoramas"
     ],
     "packing_nudges": [
       "Heavy layers for fall/spring",
-      "Very warm clothing for winter (below 0°F possible)",
+      "Very warm clothing for winter (below 0\u00b0F possible)",
       "Light clothing for summer",
       "Comfortable walking shoes for cobblestones",
       "Rain jacket"
@@ -35291,7 +35899,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "69-87°F year-round tropical",
+      "temp_range": "69-87\u00b0F year-round tropical",
       "humidity": "High; slightly lower dry season",
       "rain": "Wet season Nov-Apr; drier May-Oct",
       "wind": "Light trade winds",
@@ -35342,7 +35950,7 @@
       "Stingray and shark feeding excursions are popular but controversial",
       "The pineapple plantations are unique and worth visiting",
       "Belvedere Lookout offers stunning views of both bays",
-      "Much smaller than Tahiti — can be explored in a day"
+      "Much smaller than Tahiti \u2014 can be explored in a day"
     ],
     "packing_nudges": [
       "Light beach clothing",
@@ -35353,7 +35961,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Nov – Apr (South Pacific cyclone season)",
+      "hurricane_season": "Nov \u2013 Apr (South Pacific cyclone season)",
       "peak_risk_months": [
         "Jan",
         "Feb",
@@ -35459,7 +36067,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "67-92°F year-round warm",
+      "temp_range": "67-92\u00b0F year-round warm",
       "humidity": "Low winter; extreme monsoon",
       "rain": "Monsoon Jun-Sep brings extreme flooding; Oct-May dry",
       "wind": "Strong monsoon winds",
@@ -35500,7 +36108,7 @@
       "Aug"
     ],
     "catches_off_guard": [
-      "Mumbai monsoon flooding is legendary — the city can shut down entirely",
+      "Mumbai monsoon flooding is legendary \u2014 the city can shut down entirely",
       "Local trains stop running during heavy monsoon rains",
       "Gateway of India and Marine Drive are exposed to monsoon spray",
       "Bollywood studio tours operate year-round",
@@ -35515,7 +36123,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Nov – Apr (Indian Ocean cyclone season)",
+      "hurricane_season": "Nov \u2013 Apr (Indian Ocean cyclone season)",
       "peak_risk_months": [
         "Jan",
         "Feb",
@@ -35621,9 +36229,9 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "63-104°F desert coastal range",
+      "temp_range": "63-104\u00b0F desert coastal range",
       "humidity": "Moderate; higher coastal than inland",
-      "rain": "Almost none — occasional winter showers",
+      "rain": "Almost none \u2014 occasional winter showers",
       "wind": "Khareef (monsoon) brings fog to Salalah but rarely Muscat",
       "daylight": "10.5-13.5 hours seasonal"
     },
@@ -35668,8 +36276,8 @@
     "catches_off_guard": [
       "The Sultan Qaboos Grand Mosque requires full modest dress",
       "Wadis (dry riverbeds) can flash flood with surprising speed",
-      "Muscat is spread along 40km of coast — walking between sites is impractical",
-      "Omani hospitality is legendary — engage with locals",
+      "Muscat is spread along 40km of coast \u2014 walking between sites is impractical",
+      "Omani hospitality is legendary \u2014 engage with locals",
       "The fish market at Muttrah is a must-visit early morning"
     ],
     "packing_nudges": [
@@ -35781,10 +36389,10 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "57-82°F; hot dry summers, mild wet winters",
-      "humidity": "Low to Moderate (58-73%) — dry island climate",
+      "temp_range": "57-82\u00b0F; hot dry summers, mild wet winters",
+      "humidity": "Low to Moderate (58-73%) \u2014 dry island climate",
       "rain": "Virtually no rain Jun-Aug; wettest Nov-Feb",
-      "wind": "Famous Meltemi winds Jun-Sep — strong, persistent, cooling",
+      "wind": "Famous Meltemi winds Jun-Sep \u2014 strong, persistent, cooling",
       "daylight": "9-15 hours; party island comes alive after dark in summer"
     },
     "best_months_for": {
@@ -35826,11 +36434,11 @@
     ],
     "catches_off_guard": [
       "Meltemi winds can make beaches uncomfortable despite hot weather",
-      "Tender port — ships anchor offshore, can be wavy in wind",
+      "Tender port \u2014 ships anchor offshore, can be wavy in wind",
       "July-August winds can delay or cancel tender service",
       "Extremely expensive compared to other Greek islands",
       "Windmills and Little Venice area mobbed when cruise ships in",
-      "Beach clubs have minimum spends (€50+ per person)"
+      "Beach clubs have minimum spends (\u20ac50+ per person)"
     ],
     "packing_nudges": [
       "Windbreaker or light jacket (winds are stronger than you expect)",
@@ -35943,7 +36551,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "65-85°F year-round tropical",
+      "temp_range": "65-85\u00b0F year-round tropical",
       "humidity": "High; drier Jun-Oct",
       "rain": "Wet Nov-Apr; dry May-Oct",
       "wind": "Trade winds",
@@ -35976,11 +36584,11 @@
       "Mar"
     ],
     "catches_off_guard": [
-      "Mystery Island is tiny — you can walk around it in 20 minutes",
+      "Mystery Island is tiny \u2014 you can walk around it in 20 minutes",
       "It's uninhabited except when cruise ships visit",
       "Locals from nearby islands set up stalls on cruise days",
       "The airstrip doubles as the main walking path",
-      "Snorkeling off the beach is the main activity — bring your own gear"
+      "Snorkeling off the beach is the main activity \u2014 bring your own gear"
     ],
     "packing_nudges": [
       "Swimwear and cover-up",
@@ -35991,7 +36599,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Nov – Apr (South Pacific cyclone season)",
+      "hurricane_season": "Nov \u2013 Apr (South Pacific cyclone season)",
       "peak_risk_months": [
         "Jan",
         "Feb",
@@ -36097,7 +36705,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "38-86°F four seasons",
+      "temp_range": "38-86\u00b0F four seasons",
       "humidity": "Muggy Jun-Sep; moderate otherwise",
       "rain": "Heavy rainy season Jun-Jul; wettest city in Japan",
       "wind": "Moderate; sheltered harbor",
@@ -36127,8 +36735,8 @@
       "Aug"
     ],
     "catches_off_guard": [
-      "Nagasaki gets more rain than most Japanese cities — always carry rain gear",
-      "The city is very hilly — comfortable shoes are essential",
+      "Nagasaki gets more rain than most Japanese cities \u2014 always carry rain gear",
+      "The city is very hilly \u2014 comfortable shoes are essential",
       "Glover Garden and Peace Park are exposed to weather",
       "Chinatown is a great rainy-day option",
       "Summer heat and humidity are taxing on the steep streets"
@@ -36142,7 +36750,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "May – Nov (Western Pacific typhoon season)",
+      "hurricane_season": "May \u2013 Nov (Western Pacific typhoon season)",
       "peak_risk_months": [
         "Aug",
         "Sep",
@@ -36248,7 +36856,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "39-77°F — New Zealand's sunniest city",
+      "temp_range": "39-77\u00b0F \u2014 New Zealand's sunniest city",
       "humidity": "Moderate",
       "rain": "Distributed year-round; one of NZ's driest",
       "wind": "Moderate; sheltered by ranges",
@@ -36290,8 +36898,8 @@
     "avoid_months": [],
     "catches_off_guard": [
       "Napier has the world's best collection of Art Deco architecture",
-      "Hawke's Bay wine region is excellent — especially red wines",
-      "New Zealand's sunniest city — but UV is still extreme",
+      "Hawke's Bay wine region is excellent \u2014 especially red wines",
+      "New Zealand's sunniest city \u2014 but UV is still extreme",
       "Cape Kidnappers gannet colony is a unique excursion",
       "The 1931 earthquake that leveled the city enabled the Art Deco rebuild"
     ],
@@ -36404,8 +37012,8 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "54-85°F; hot humid summers, mild winters",
-      "humidity": "Moderate to High (63-73%) — humid in summer",
+      "temp_range": "54-85\u00b0F; hot humid summers, mild winters",
+      "humidity": "Moderate to High (63-73%) \u2014 humid in summer",
       "rain": "Wettest Oct-Dec; dry hot summers",
       "wind": "Coastal breezes; Vesuvius can create local wind patterns",
       "daylight": "9-15 hours; long evenings for Amalfi Coast tours"
@@ -36446,8 +37054,8 @@
       "Aug"
     ],
     "catches_off_guard": [
-      "Naples traffic is chaotic — allow extra time for port return",
-      "Pompeii in summer heat (95°F+) is exhausting with no shade",
+      "Naples traffic is chaotic \u2014 allow extra time for port return",
+      "Pompeii in summer heat (95\u00b0F+) is exhausting with no shade",
       "Amalfi Coast roads are narrow, winding, and nerve-wracking",
       "Pickpockets and bag snatchers very active near port and train station",
       "Vesuvius can be cloudy/obscured even on otherwise clear days",
@@ -36564,7 +37172,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "65-90°F year-round",
+      "temp_range": "65-90\u00b0F year-round",
       "humidity": "Moderate to high (71-79%)",
       "rain": "Brief showers; heaviest Jun-Oct",
       "wind": "Easterly trades; strongest Dec-Apr",
@@ -36601,10 +37209,10 @@
       "Oct"
     ],
     "catches_off_guard": [
-      "Hurricane season peaks Sep-Oct — ships may reroute",
+      "Hurricane season peaks Sep-Oct \u2014 ships may reroute",
       "Cruise port area is heavily tourist-oriented",
       "Summer humidity can feel oppressive",
-      "Sun reflects off white sand — double up on sunscreen",
+      "Sun reflects off white sand \u2014 double up on sunscreen",
       "Rip currents on north-facing beaches"
     ],
     "packing_nudges": [
@@ -36615,7 +37223,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Sep",
         "Oct"
@@ -36721,7 +37329,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "64-86°F — Garden Isle tropical",
+      "temp_range": "64-86\u00b0F \u2014 Garden Isle tropical",
       "humidity": "Moderate; varies by location",
       "rain": "Wet north/east; dry south/west; Mt. Waialeale is wettest spot on Earth",
       "wind": "Trade winds; calmer in summer",
@@ -36764,18 +37372,18 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "Nā Pali Coast is accessible only by helicopter, boat, or serious hiking",
+      "N\u0101 Pali Coast is accessible only by helicopter, boat, or serious hiking",
       "Waimea Canyon ('Grand Canyon of the Pacific') is stunning",
-      "Mt. Waialeale gets 450+ inches of rain per year — one of wettest spots on Earth",
+      "Mt. Waialeale gets 450+ inches of rain per year \u2014 one of wettest spots on Earth",
       "Poipu Beach (south shore) is consistently sunny",
       "The Kalalau Trail is challenging but one of world's great hikes"
     ],
     "packing_nudges": [
-      "Light layers — weather varies by coast",
+      "Light layers \u2014 weather varies by coast",
       "Rain jacket for north shore excursions",
       "Sturdy hiking shoes for canyon/trails",
       "Reef-safe sunscreen",
-      "Binoculars for Nā Pali Coast views"
+      "Binoculars for N\u0101 Pali Coast views"
     ],
     "hazards": {
       "hurricane_zone": false
@@ -36879,8 +37487,8 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "63-91°F; hot oppressive summers, mild pleasant winters",
-      "humidity": "High (70-77%) — swampy subtropical climate year-round",
+      "temp_range": "63-91\u00b0F; hot oppressive summers, mild pleasant winters",
+      "humidity": "High (70-77%) \u2014 swampy subtropical climate year-round",
       "rain": "Heavy downpours possible year-round; wettest Jun-Aug",
       "wind": "Light; humidity and heat can feel stifling in summer",
       "daylight": "10-14 hours; consistent year-round"
@@ -36930,12 +37538,12 @@
       "Sep"
     ],
     "catches_off_guard": [
-      "Summer heat + humidity is oppressive — 90°F feels like 110°F",
+      "Summer heat + humidity is oppressive \u2014 90\u00b0F feels like 110\u00b0F",
       "Hurricane season Aug-Oct means possible cruise cancellations",
       "Afternoon thunderstorms in summer are intense with flooding",
       "French Quarter can smell bad in summer (heat, trash, drainage)",
-      "Mardi Gras is insane — book way ahead or avoid Feb entirely",
-      "Port is far from French Quarter — taxi/Uber required"
+      "Mardi Gras is insane \u2014 book way ahead or avoid Feb entirely",
+      "Port is far from French Quarter \u2014 taxi/Uber required"
     ],
     "packing_nudges": [
       "Moisture-wicking breathable clothes for summer",
@@ -36947,7 +37555,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic/Gulf)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic/Gulf)",
       "peak_risk_months": [
         "Aug",
         "Sep"
@@ -37053,7 +37661,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "43-82°F temperate coastal",
+      "temp_range": "43-82\u00b0F temperate coastal",
       "humidity": "Moderate",
       "rain": "Distributed year-round; drier winter",
       "wind": "Sea breezes afternoon",
@@ -37210,7 +37818,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "24-80°F — New England coastal",
+      "temp_range": "24-80\u00b0F \u2014 New England coastal",
       "humidity": "Moderate",
       "rain": "Distributed year-round; drier summer",
       "wind": "Can be strong; famous sailing port",
@@ -37255,13 +37863,13 @@
     "avoid_months": [],
     "catches_off_guard": [
       "The Gilded Age mansions (Breakers, Marble House) are the top attractions",
-      "Cliff Walk combines mansion views with ocean scenery — spectacular",
-      "Newport is America's sailing capital — harbor tours are popular",
+      "Cliff Walk combines mansion views with ocean scenery \u2014 spectacular",
+      "Newport is America's sailing capital \u2014 harbor tours are popular",
       "Thames Street has excellent restaurants and shopping",
       "The International Tennis Hall of Fame is here"
     ],
     "packing_nudges": [
-      "Layers — ocean breezes make it cooler than expected",
+      "Layers \u2014 ocean breezes make it cooler than expected",
       "Light jacket even in summer",
       "Comfortable walking shoes for Cliff Walk",
       "Rain jacket",
@@ -37269,7 +37877,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Sep",
         "Oct"
@@ -37374,7 +37982,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "70-90°F year-round warm",
+      "temp_range": "70-90\u00b0F year-round warm",
       "humidity": "Moderate by tropical standards",
       "rain": "Wettest Oct-Dec; dry season Jan-Aug",
       "wind": "Northeast monsoon brings rain Oct-Dec",
@@ -37534,7 +38142,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "32-87°F — mid-Atlantic four seasons",
+      "temp_range": "32-87\u00b0F \u2014 mid-Atlantic four seasons",
       "humidity": "Moderate; humid summers",
       "rain": "Distributed year-round; wettest Jul-Aug",
       "wind": "Moderate coastal breezes",
@@ -37572,7 +38180,7 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "Naval Station Norfolk is the world's largest naval base — tours available",
+      "Naval Station Norfolk is the world's largest naval base \u2014 tours available",
       "The Nauticus maritime museum has the battleship USS Wisconsin",
       "Virginia Beach is 30 min away for beach excursions",
       "Ghent neighborhood has the best dining and shopping",
@@ -37587,7 +38195,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Sep",
         "Oct"
@@ -37692,7 +38300,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "25-65°F — dramatic fjord climate",
+      "temp_range": "25-65\u00b0F \u2014 dramatic fjord climate",
       "humidity": "Moderate to high",
       "rain": "Frequent; driest May-Jun",
       "wind": "Variable; sheltered in fjords, exposed outside",
@@ -37731,10 +38339,10 @@
     ],
     "catches_off_guard": [
       "Midnight sun above the Arctic Circle (late May-late Jul) is magical",
-      "Each fjord has its own character — Geiranger and Sognefjord are the most famous",
+      "Each fjord has its own character \u2014 Geiranger and Sognefjord are the most famous",
       "Waterfalls are at their best in May-Jun during snowmelt",
       "Norwegian fjord cruises often include scenic train rides",
-      "Even summer can be cool — layers are essential"
+      "Even summer can be cool \u2014 layers are essential"
     ],
     "packing_nudges": [
       "Warm layers even in summer",
@@ -37845,7 +38453,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "67-89°F year-round tropical",
+      "temp_range": "67-89\u00b0F year-round tropical",
       "humidity": "High wet season; lower dry season",
       "rain": "Wet season Nov-Mar; dry Apr-Oct",
       "wind": "Light; trade winds provide relief in dry season",
@@ -37892,10 +38500,10 @@
       "Mar"
     ],
     "catches_off_guard": [
-      "Cyclone season (Jan-Mar) poses real risk — ships may cancel",
+      "Cyclone season (Jan-Mar) poses real risk \u2014 ships may cancel",
       "Lemurs and chameleons are best seen in dry season",
       "Ylang-ylang plantations perfume the entire island",
-      "Infrastructure is basic — don't expect luxury facilities",
+      "Infrastructure is basic \u2014 don't expect luxury facilities",
       "Whale sharks visit Apr-Nov"
     ],
     "packing_nudges": [
@@ -37907,7 +38515,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Nov – Apr (Indian Ocean cyclone season)",
+      "hurricane_season": "Nov \u2013 Apr (Indian Ocean cyclone season)",
       "peak_risk_months": [
         "Jan",
         "Feb",
@@ -38013,7 +38621,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "61-85°F — French-influenced Pacific",
+      "temp_range": "61-85\u00b0F \u2014 French-influenced Pacific",
       "humidity": "Moderate to high",
       "rain": "Wetter Dec-Apr; drier Jun-Sep",
       "wind": "Trade winds year-round",
@@ -38060,7 +38668,7 @@
       "French cuisine and boulangeries in a tropical setting",
       "The Tjibaou Cultural Centre is architecturally stunning",
       "Nickel mining has impacted some landscapes",
-      "CFP franc currency — same as French Polynesia"
+      "CFP franc currency \u2014 same as French Polynesia"
     ],
     "packing_nudges": [
       "Light breathable clothing",
@@ -38071,7 +38679,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Nov – Apr (South Pacific cyclone season)",
+      "hurricane_season": "Nov \u2013 Apr (South Pacific cyclone season)",
       "peak_risk_months": [
         "Jan",
         "Feb",
@@ -38177,7 +38785,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "71-89°F year-round",
+      "temp_range": "71-89\u00b0F year-round",
       "humidity": "Moderate to high (72-80%)",
       "rain": "Wetter than Montego Bay; peaks May-Jun and Sep-Nov",
       "wind": "Trades; sheltered harbor",
@@ -38209,7 +38817,7 @@
       "Oct"
     ],
     "catches_off_guard": [
-      "Dunn's River Falls climb is slippery — water shoes mandatory",
+      "Dunn's River Falls climb is slippery \u2014 water shoes mandatory",
       "Vendors are persistent",
       "Town walkable but hilly",
       "Rain in hills can be sudden",
@@ -38223,7 +38831,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Sep",
         "Oct"
@@ -38329,7 +38937,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "57-88°F subtropical",
+      "temp_range": "57-88\u00b0F subtropical",
       "humidity": "High year-round; peak Jun-Sep",
       "rain": "Heavy rainy season May-Jun (tsuyu); typhoons Jul-Oct",
       "wind": "Moderate trade winds",
@@ -38369,7 +38977,7 @@
       "Typhoon season (Jul-Oct) regularly disrupts port calls",
       "Rainy season (May-Jun) brings heavy persistent rain",
       "Okinawa's culture is distinct from mainland Japan",
-      "UV index is extreme — sunburn happens fast",
+      "UV index is extreme \u2014 sunburn happens fast",
       "Ocean water is warm enough for swimming Apr-Nov"
     ],
     "packing_nudges": [
@@ -38381,7 +38989,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "May – Nov (Western Pacific typhoon season)",
+      "hurricane_season": "May \u2013 Nov (Western Pacific typhoon season)",
       "peak_risk_months": [
         "Aug",
         "Sep",
@@ -38487,7 +39095,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "22-66°F — Nordfjord gateway",
+      "temp_range": "22-66\u00b0F \u2014 Nordfjord gateway",
       "humidity": "Moderate to high (59-77%)",
       "rain": "Wet year-round",
       "wind": "Sheltered fjord",
@@ -38530,10 +39138,10 @@
       "Mar"
     ],
     "catches_off_guard": [
-      "Gateway to Briksdal Glacier — popular excursion",
+      "Gateway to Briksdal Glacier \u2014 popular excursion",
       "Glacier hike requires good fitness and appropriate gear",
-      "Loen Skylift opened recently — stunning views",
-      "Village is very small — excursions are the point",
+      "Loen Skylift opened recently \u2014 stunning views",
+      "Village is very small \u2014 excursions are the point",
       "Oldedalen valley is picturesque drive"
     ],
     "packing_nudges": [
@@ -38645,7 +39253,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "34-88°F four seasons",
+      "temp_range": "34-88\u00b0F four seasons",
       "humidity": "Muggy Jun-Sep; mild otherwise",
       "rain": "Rainy season Jun-Jul; typhoons Aug-Oct",
       "wind": "Light to moderate",
@@ -38680,7 +39288,7 @@
       "Aug"
     ],
     "catches_off_guard": [
-      "Osaka is Japan's food capital — budget extra for eating",
+      "Osaka is Japan's food capital \u2014 budget extra for eating",
       "Summer is stifling hot and humid",
       "Typhoons can disrupt port calls in September",
       "The rainy season (Jun-Jul) brings persistent drizzle",
@@ -38695,7 +39303,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "May – Nov (Western Pacific typhoon season)",
+      "hurricane_season": "May \u2013 Nov (Western Pacific typhoon season)",
       "peak_risk_months": [
         "Aug",
         "Sep",
@@ -38801,7 +39409,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "20-72°F — distinct four seasons",
+      "temp_range": "20-72\u00b0F \u2014 distinct four seasons",
       "humidity": "Moderate (55-81%)",
       "rain": "Year-round; wetter late summer",
       "wind": "Sheltered by fjord",
@@ -38848,7 +39456,7 @@
       "Vigeland Sculpture Park is free and extraordinary",
       "Akershus Fortress overlooks harbor",
       "One of world's most expensive cities",
-      "Seasonal daylight varies dramatically — 6hr winter, 18hr summer"
+      "Seasonal daylight varies dramatically \u2014 6hr winter, 18hr summer"
     ],
     "packing_nudges": [
       "Layers for all seasons",
@@ -38959,7 +39567,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "76-87°F year-round equatorial",
+      "temp_range": "76-87\u00b0F year-round equatorial",
       "humidity": "Very high year-round",
       "rain": "Rain year-round; slightly drier Feb-Apr",
       "wind": "Light; occasional typhoon threat",
@@ -38995,8 +39603,8 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "Jellyfish Lake is a unique global phenomenon — swimming with millions of stingless jellyfish",
-      "Rock Islands are UNESCO World Heritage — spectacular from any angle",
+      "Jellyfish Lake is a unique global phenomenon \u2014 swimming with millions of stingless jellyfish",
+      "Rock Islands are UNESCO World Heritage \u2014 spectacular from any angle",
       "Palau charges a Pristine Paradise Environmental Fee on entry",
       "Strong currents make some dive sites challenging",
       "Traditional Palauan culture is matrilineal"
@@ -39110,7 +39718,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "40-86°F — Mallorca has warm summers, mild winters",
+      "temp_range": "40-86\u00b0F \u2014 Mallorca has warm summers, mild winters",
       "humidity": "Moderate (53-76%)",
       "rain": "Dry summers; wetter Oct-Jan",
       "wind": "Occasional tramuntana from mountains",
@@ -39153,8 +39761,8 @@
     "catches_off_guard": [
       "Professional cycling teams train here Mar-Apr",
       "Cathedral (La Seu) is spectacular, especially at sunset",
-      "Deià and Sóller in mountains are magical day trips",
-      "Palma is genuinely cosmopolitan — excellent restaurants",
+      "Dei\u00e0 and S\u00f3ller in mountains are magical day trips",
+      "Palma is genuinely cosmopolitan \u2014 excellent restaurants",
       "Beach clubs on Playa de Palma can be rowdy in summer"
     ],
     "packing_nudges": [
@@ -39266,7 +39874,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "74-92°F year-round tropical",
+      "temp_range": "74-92\u00b0F year-round tropical",
       "humidity": "High year-round; very high in wet season",
       "rain": "Dry season Jan-Apr; wet May-Dec",
       "wind": "Light; sheltered canal zone",
@@ -39299,7 +39907,7 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "Full canal transit takes 8-10 hours — it's a full-day experience",
+      "Full canal transit takes 8-10 hours \u2014 it's a full-day experience",
       "Gatun Lake in the middle of the canal is a freshwater tropical lake",
       "Miraflores Locks visitor center is worth visiting if doing partial transit",
       "The canal expansion (2016) allows much larger cruise ships through",
@@ -39414,7 +40022,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "69-87°F year-round tropical",
+      "temp_range": "69-87\u00b0F year-round tropical",
       "humidity": "High; slightly lower in dry season",
       "rain": "Wet season Nov-Apr; drier May-Oct",
       "wind": "Trade winds year-round",
@@ -39457,11 +40065,11 @@
       "Feb"
     ],
     "catches_off_guard": [
-      "Papeete market (Le Marché) is one of the best in the Pacific",
+      "Papeete market (Le March\u00e9) is one of the best in the Pacific",
       "Tahitian pearls are significantly cheaper here than elsewhere",
       "July Heiva festival is a spectacular cultural celebration",
       "Traffic in Papeete can be surprisingly bad",
-      "French Polynesia uses CFP francs — not euros"
+      "French Polynesia uses CFP francs \u2014 not euros"
     ],
     "packing_nudges": [
       "Light breathable clothing",
@@ -39472,7 +40080,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Nov – Apr (South Pacific cyclone season)",
+      "hurricane_season": "Nov \u2013 Apr (South Pacific cyclone season)",
       "peak_risk_months": [
         "Jan",
         "Feb",
@@ -39578,7 +40186,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "45-86°F — holy island, peaceful",
+      "temp_range": "45-86\u00b0F \u2014 holy island, peaceful",
       "humidity": "Low to moderate (38-71%)",
       "rain": "Dry May-Sep; wet winters",
       "wind": "Meltemi Jul-Aug",
@@ -39614,7 +40222,7 @@
     "avoid_months": [],
     "catches_off_guard": [
       "Monastery of St. John and Cave of Apocalypse are UNESCO",
-      "Small island — tender port",
+      "Small island \u2014 tender port",
       "Peaceful, spiritual atmosphere unlike party islands",
       "Skala harbor village is charming",
       "Grikos Bay is best beach"
@@ -39623,7 +40231,7 @@
       "Modest clothing for monastery",
       "Comfortable walking shoes for hill to monastery",
       "Sunscreen",
-      "Cash — limited ATMs"
+      "Cash \u2014 limited ATMs"
     ],
     "hazards": {
       "hurricane_zone": false,
@@ -39728,7 +40336,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "75-91°F year-round tropical",
+      "temp_range": "75-91\u00b0F year-round tropical",
       "humidity": "High year-round; wettest Sep-Nov",
       "rain": "Two monsoon peaks; driest Jan-Mar",
       "wind": "Light monsoon winds",
@@ -39768,9 +40376,9 @@
       "Nov"
     ],
     "catches_off_guard": [
-      "Penang is Malaysia's food capital — budget time for hawker centers",
+      "Penang is Malaysia's food capital \u2014 budget time for hawker centers",
       "Georgetown's street art is best explored on foot in dry weather",
-      "Heritage buildings have no AC — it's hot inside too",
+      "Heritage buildings have no AC \u2014 it's hot inside too",
       "Monsoon rain (Sep-Nov) can be relentless for days",
       "Penang Hill funicular offers cooler temperatures and views"
     ],
@@ -39802,6 +40410,158 @@
         "Jul",
         "Aug",
         "Sep"
+      ]
+    }
+  },
+  "petersburg": {
+    "tier": 1,
+    "timezone": "America/Anchorage",
+    "_source": "High/low: Petersburg 1 NOAA 1991-2020 (Wikipedia climate table, station USW00025329, session 2026-09-03). Rain_days and humidity: Sitka entry in this file (nearest SE Alaska station with those fields).",
+    "monthly_averages": {
+      "jan": {
+        "high_f": 35,
+        "low_f": 27,
+        "rain_days": 17,
+        "humidity": 78
+      },
+      "feb": {
+        "high_f": 37,
+        "low_f": 28,
+        "rain_days": 15,
+        "humidity": 77
+      },
+      "mar": {
+        "high_f": 40,
+        "low_f": 30,
+        "rain_days": 16,
+        "humidity": 75
+      },
+      "apr": {
+        "high_f": 48,
+        "low_f": 35,
+        "rain_days": 15,
+        "humidity": 75
+      },
+      "may": {
+        "high_f": 55,
+        "low_f": 42,
+        "rain_days": 14,
+        "humidity": 76
+      },
+      "jun": {
+        "high_f": 60,
+        "low_f": 48,
+        "rain_days": 14,
+        "humidity": 78
+      },
+      "jul": {
+        "high_f": 62,
+        "low_f": 51,
+        "rain_days": 14,
+        "humidity": 80
+      },
+      "aug": {
+        "high_f": 61,
+        "low_f": 50,
+        "rain_days": 16,
+        "humidity": 82
+      },
+      "sep": {
+        "high_f": 56,
+        "low_f": 46,
+        "rain_days": 19,
+        "humidity": 83
+      },
+      "oct": {
+        "high_f": 47,
+        "low_f": 39,
+        "rain_days": 21,
+        "humidity": 82
+      },
+      "nov": {
+        "high_f": 39,
+        "low_f": 32,
+        "rain_days": 18,
+        "humidity": 80
+      },
+      "dec": {
+        "high_f": 35,
+        "low_f": 28,
+        "rain_days": 18,
+        "humidity": 79
+      }
+    },
+    "at_a_glance": {
+      "temp_range": "27-62\u00b0F \u2014 Little Norway, Mitkof Island",
+      "humidity": "High; SE rainforest",
+      "rain": "~110 in/year at the NOAA station",
+      "wind": "Wrangell Narrows is sheltered; Frederick Sound is not",
+      "daylight": "7-18 hours (seasonal)"
+    },
+    "best_months_for": {
+      "leconte_glacier": [
+        "May",
+        "Jun",
+        "Jul",
+        "Aug"
+      ],
+      "city_walking": [
+        "Jun",
+        "Jul",
+        "Aug"
+      ],
+      "fishing": [
+        "Jun",
+        "Jul",
+        "Aug",
+        "Sep"
+      ],
+      "low_crowds": [
+        "May",
+        "Sep"
+      ]
+    },
+    "avoid_months": [
+      "Nov",
+      "Dec",
+      "Jan",
+      "Feb",
+      "Mar"
+    ],
+    "catches_off_guard": [
+      "Mega-ships skip this port \u2014 Wrangell Narrows is too tight",
+      "Small expedition ships and the ferry are the usual callers",
+      "Norwegian Constitution weekend (mid-May) is the town's busy social peak",
+      "LeConte Glacier is a boat trip, not a walk from the dock",
+      "Rain totals rival Sitka"
+    ],
+    "packing_nudges": [
+      "Waterproof jacket and boots",
+      "Layers for 50s\u00b0F summer",
+      "Warm hat",
+      "Cash for a small town"
+    ],
+    "hazards": {
+      "hurricane_zone": false
+    },
+    "cruise_seasons": {
+      "high": [
+        "Jun",
+        "Jul",
+        "Aug"
+      ],
+      "transitional": [
+        "May",
+        "Sep"
+      ],
+      "low": [
+        "Oct",
+        "Nov",
+        "Dec",
+        "Jan",
+        "Feb",
+        "Mar",
+        "Apr"
       ]
     }
   },
@@ -39883,7 +40643,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "73-89°F year-round",
+      "temp_range": "73-89\u00b0F year-round",
       "humidity": "Moderate (71-77%)",
       "rain": "Brief showers; wetter Sep-Nov",
       "wind": "Trades; lighter fall",
@@ -39919,9 +40679,9 @@
       "Sep"
     ],
     "catches_off_guard": [
-      "Maho Beach jet blast is real — stay behind fence",
-      "Dutch/French split — different vibes",
-      "5+ ships at once — intense crowds",
+      "Maho Beach jet blast is real \u2014 stay behind fence",
+      "Dutch/French split \u2014 different vibes",
+      "5+ ships at once \u2014 intense crowds",
       "French side quieter with better food",
       "Orient Bay is clothing-optional"
     ],
@@ -39933,7 +40693,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Aug",
         "Sep",
@@ -40040,7 +40800,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "75-91°F year-round tropical",
+      "temp_range": "75-91\u00b0F year-round tropical",
       "humidity": "High year-round; wettest May-Oct",
       "rain": "Southwest monsoon May-Oct; dry season Nov-Apr",
       "wind": "Monsoon winds create rough seas May-Oct",
@@ -40083,7 +40843,7 @@
     "catches_off_guard": [
       "Southwest monsoon (May-Oct) makes west coast beaches dangerous for swimming",
       "Andaman Sea visibility drops dramatically in monsoon season",
-      "Rip currents claim lives every year — respect red flags",
+      "Rip currents claim lives every year \u2014 respect red flags",
       "Dry season brings crystal-clear water and calm seas",
       "Some islands close entirely during monsoon season"
     ],
@@ -40196,7 +40956,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "35-72°F — sheltered Marlborough Sounds",
+      "temp_range": "35-72\u00b0F \u2014 sheltered Marlborough Sounds",
       "humidity": "Moderate",
       "rain": "Distributed; lighter than west coast",
       "wind": "Sheltered by sounds; calmer than open coast",
@@ -40234,10 +40994,10 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "Picton is the gateway to the Marlborough Sounds — stunning scenery",
+      "Picton is the gateway to the Marlborough Sounds \u2014 stunning scenery",
       "Queen Charlotte Track is a world-class multi-day walk",
       "Marlborough wine region (Sauvignon Blanc) is nearby",
-      "The inter-island ferry crosses through here — busy port",
+      "The inter-island ferry crosses through here \u2014 busy port",
       "Edwin Fox is one of the world's oldest ships, on display here"
     ],
     "packing_nudges": [
@@ -40349,10 +41109,10 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "60-81°F mild oceanic year-round",
+      "temp_range": "60-81\u00b0F mild oceanic year-round",
       "humidity": "Moderate to high",
       "rain": "Distributed year-round; no true dry season",
-      "wind": "Can be rough — exposed location",
+      "wind": "Can be rough \u2014 exposed location",
       "daylight": "10.5-13.5 hours (Southern Hemisphere)"
     },
     "best_months_for": {
@@ -40383,18 +41143,18 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "Pitcairn has about 50 residents — descendants of HMS Bounty mutineers",
-      "Landing depends entirely on sea conditions — often impossible",
-      "There is no harbor — longboats transfer passengers from anchored ships",
+      "Pitcairn has about 50 residents \u2014 descendants of HMS Bounty mutineers",
+      "Landing depends entirely on sea conditions \u2014 often impossible",
+      "There is no harbor \u2014 longboats transfer passengers from anchored ships",
       "Adamstown is the world's smallest capital",
-      "Honey from Pitcairn is prized — completely disease-free bees"
+      "Honey from Pitcairn is prized \u2014 completely disease-free bees"
     ],
     "packing_nudges": [
       "Sturdy shoes for rough terrain",
       "Waterproof layers",
       "Light warm layers",
       "Camera",
-      "Cash — no ATMs or card machines"
+      "Cash \u2014 no ATMs or card machines"
     ],
     "hazards": {
       "hurricane_zone": false
@@ -40498,7 +41258,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "48-76°F — cool maritime, very green",
+      "temp_range": "48-76\u00b0F \u2014 cool maritime, very green",
       "humidity": "High (75-78%)",
       "rain": "Rain year-round; drier Jun-Aug",
       "wind": "Frequently windy; Atlantic storms",
@@ -40544,14 +41304,14 @@
       "Feb"
     ],
     "catches_off_guard": [
-      "Azores are mid-Atlantic — weather changes hour to hour",
+      "Azores are mid-Atlantic \u2014 weather changes hour to hour",
       "Sete Cidades twin lakes are spectacular",
       "Whale watching is world-class (sperm whales year-round)",
       "Hot springs at Furnas are a unique experience",
       "Cozido (stew cooked in volcanic ground) is signature dish"
     ],
     "packing_nudges": [
-      "Waterproof jacket — essential year-round",
+      "Waterproof jacket \u2014 essential year-round",
       "Layers for changeable weather",
       "Hiking boots for volcanic trails",
       "Motion sickness remedy for whale watching boats"
@@ -40659,10 +41419,10 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "36-70°F cool maritime",
+      "temp_range": "36-70\u00b0F cool maritime",
       "humidity": "Moderate to high",
       "rain": "Frequent year-round; winter slightly wetter",
-      "wind": "Exposed coastal location — often windy",
+      "wind": "Exposed coastal location \u2014 often windy",
       "daylight": "9-15.5 hours (Southern Hemisphere)"
     },
     "best_months_for": {
@@ -40696,9 +41456,9 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "The historic penal settlement is largely outdoors — dress for weather",
+      "The historic penal settlement is largely outdoors \u2014 dress for weather",
       "Ghost tours operate at night and can be very cold",
-      "The site is emotionally intense — colonial punishment history",
+      "The site is emotionally intense \u2014 colonial punishment history",
       "Tasman Peninsula has spectacular sea cliffs",
       "Port Arthur is ~1.5 hours from Hobart"
     ],
@@ -40711,7 +41471,7 @@
     ],
     "hazards": {
       "hurricane_zone": false,
-      "note": "The historic penal settlement is largely outdoors — dress for weather. Ghost tours operate at night and can be very cold."
+      "note": "The historic penal settlement is largely outdoors \u2014 dress for weather. Ghost tours operate at night and can be very cold."
     },
     "cruise_seasons": {
       "high": [
@@ -40812,8 +41572,8 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "71-90°F; hot summers, warm winters, near Orlando",
-      "humidity": "Moderate to High (64-76%) — less humid than South Florida",
+      "temp_range": "71-90\u00b0F; hot summers, warm winters, near Orlando",
+      "humidity": "Moderate to High (64-76%) \u2014 less humid than South Florida",
       "rain": "Daily afternoon thunderstorms Jun-Sep, brief but intense",
       "wind": "Ocean breezes moderate heat; stronger in storms",
       "daylight": "10-14 hours; fairly consistent"
@@ -40857,12 +41617,12 @@
       "Sep"
     ],
     "catches_off_guard": [
-      "Summer afternoon thunderstorms have intense lightning — seek shelter",
+      "Summer afternoon thunderstorms have intense lightning \u2014 seek shelter",
       "Hurricane season means possible cruise cancellations/diversions",
-      "Port is industrial — limited walkable attractions",
-      "Orlando is 60-90 min away — theme parks not realistic for port day",
+      "Port is industrial \u2014 limited walkable attractions",
+      "Orlando is 60-90 min away \u2014 theme parks not realistic for port day",
       "Beach areas require taxi/Uber from port",
-      "Winter can have cool snaps (50s) — pack layers for Jan-Feb"
+      "Winter can have cool snaps (50s) \u2014 pack layers for Jan-Feb"
     ],
     "packing_nudges": [
       "Moisture-wicking clothes for summer humidity",
@@ -40874,7 +41634,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Aug",
         "Sep",
@@ -40981,10 +41741,10 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "46-79°F temperate coastal",
+      "temp_range": "46-79\u00b0F temperate coastal",
       "humidity": "Moderate year-round",
       "rain": "Evenly distributed; slightly drier winter",
-      "wind": "Can be very windy — 'Windy City' nickname",
+      "wind": "Can be very windy \u2014 'Windy City' nickname",
       "daylight": "10-14 hours (Southern Hemisphere)"
     },
     "best_months_for": {
@@ -41024,10 +41784,10 @@
     "avoid_months": [],
     "catches_off_guard": [
       "Port Elizabeth is the start of the Garden Route",
-      "Addo Elephant Park is a 1-hour drive — less crowded than Kruger",
-      "The wind can be relentless — it's called the Windy City for a reason",
+      "Addo Elephant Park is a 1-hour drive \u2014 less crowded than Kruger",
+      "The wind can be relentless \u2014 it's called the Windy City for a reason",
       "Water is cold year-round (Agulhas Current doesn't reach here)",
-      "Winter game viewing is excellent — animals congregate at water holes"
+      "Winter game viewing is excellent \u2014 animals congregate at water holes"
     ],
     "packing_nudges": [
       "Windproof jacket essential",
@@ -41138,7 +41898,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "61-91°F — South Florida tropical",
+      "temp_range": "61-91\u00b0F \u2014 South Florida tropical",
       "humidity": "Moderate dry season; high wet season",
       "rain": "Dry Nov-Apr; wet season May-Oct",
       "wind": "Trade winds; occasional tropical storms",
@@ -41175,10 +41935,10 @@
       "Sep"
     ],
     "catches_off_guard": [
-      "Port Everglades is in Fort Lauderdale — one of world's busiest cruise ports",
+      "Port Everglades is in Fort Lauderdale \u2014 one of world's busiest cruise ports",
       "Las Olas Boulevard has excellent restaurants and shopping",
-      "Everglades National Park is a unique day trip — airboat tours popular",
-      "The port is close to Fort Lauderdale beach — easily walkable",
+      "Everglades National Park is a unique day trip \u2014 airboat tours popular",
+      "The port is close to Fort Lauderdale beach \u2014 easily walkable",
       "This is primarily an embarkation/disembarkation port"
     ],
     "packing_nudges": [
@@ -41190,7 +41950,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Sep",
         "Oct"
@@ -41295,7 +42055,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "62-91°F — tropical South Florida",
+      "temp_range": "62-91\u00b0F \u2014 tropical South Florida",
       "humidity": "Moderate dry; high wet season",
       "rain": "Dry Nov-Apr; wet May-Oct",
       "wind": "Trade winds; hurricane risk",
@@ -41339,7 +42099,7 @@
       "Sep"
     ],
     "catches_off_guard": [
-      "Port Miami is the 'Cruise Capital of the World' — world's busiest",
+      "Port Miami is the 'Cruise Capital of the World' \u2014 world's busiest",
       "South Beach and the Art Deco district are a short drive/ride",
       "Little Havana's Calle Ocho has authentic Cuban culture and food",
       "Wynwood Walls street art district is a must-see",
@@ -41354,7 +42114,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Sep",
         "Oct"
@@ -41459,7 +42219,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "72-88°F year-round tropical",
+      "temp_range": "72-88\u00b0F year-round tropical",
       "humidity": "High year-round; drier Jun-Oct",
       "rain": "Wet season Dec-Apr; dry Jun-Oct",
       "wind": "Monsoon influenced",
@@ -41495,10 +42255,10 @@
       "Mar"
     ],
     "catches_off_guard": [
-      "Safety is a concern — stick to organized tour groups",
+      "Safety is a concern \u2014 stick to organized tour groups",
       "The National Museum and Parliament Haus are worth visiting",
       "Varirata National Park offers accessible nature and bird watching",
-      "PNG has over 800 languages — the most linguistically diverse country",
+      "PNG has over 800 languages \u2014 the most linguistically diverse country",
       "Organized shore excursions are strongly recommended"
     ],
     "packing_nudges": [
@@ -41510,7 +42270,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Nov – Apr (South Pacific cyclone season)",
+      "hurricane_season": "Nov \u2013 Apr (South Pacific cyclone season)",
       "peak_risk_months": [
         "Jan",
         "Feb",
@@ -41616,10 +42376,10 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "50-90°F — Suez Canal entrance, desert coast",
+      "temp_range": "50-90\u00b0F \u2014 Suez Canal entrance, desert coast",
       "humidity": "Moderate (64-71%)",
       "rain": "Almost none May-Oct; very little overall",
-      "wind": "Can be windy — sand storms possible",
+      "wind": "Can be windy \u2014 sand storms possible",
       "daylight": "10.5-14 hours"
     },
     "best_months_for": {
@@ -41656,16 +42416,16 @@
       "Aug"
     ],
     "catches_off_guard": [
-      "Gateway to Suez Canal transit — port call during canal passage",
-      "Summer heat is oppressive — 90°F+ with high humidity",
+      "Gateway to Suez Canal transit \u2014 port call during canal passage",
+      "Summer heat is oppressive \u2014 90\u00b0F+ with high humidity",
       "Colonial-era architecture from canal's 1869 opening",
-      "Not a major tourist destination — limited attractions",
+      "Not a major tourist destination \u2014 limited attractions",
       "Free Trade Zone has shopping"
     ],
     "packing_nudges": [
       "Heavy sunscreen",
       "Light breathable clothing",
-      "Water bottle — essential",
+      "Water bottle \u2014 essential",
       "Cash in Egyptian pounds"
     ],
     "hazards": {
@@ -41771,7 +42531,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "47-82°F — Algarve Mediterranean",
+      "temp_range": "47-82\u00b0F \u2014 Algarve Mediterranean",
       "humidity": "Low summer; moderate winter",
       "rain": "Dry summers; wet winter",
       "wind": "Light; Atlantic moderation",
@@ -41818,7 +42578,7 @@
     "catches_off_guard": [
       "Benagil Cave is one of Portugal's most famous natural wonders",
       "The Algarve coastline has dramatic cliffs and golden beaches",
-      "Praia da Rocha is the main beach — golden sand and sea stacks",
+      "Praia da Rocha is the main beach \u2014 golden sand and sea stacks",
       "Silves Castle (Moorish) is a scenic hilltop day trip",
       "Portuguese grilled fish and cataplana (seafood stew) are local specialties"
     ],
@@ -41931,7 +42691,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "36-67°F — Dorset coast mild maritime",
+      "temp_range": "36-67\u00b0F \u2014 Dorset coast mild maritime",
       "humidity": "Moderate to high",
       "rain": "Distributed; drier summer",
       "wind": "Can be strong; exposed coast",
@@ -41965,7 +42725,7 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "Portland is gateway to the Jurassic Coast — a UNESCO World Heritage site",
+      "Portland is gateway to the Jurassic Coast \u2014 a UNESCO World Heritage site",
       "Chesil Beach is a unique 18-mile pebble bar",
       "Portland Bill lighthouse has dramatic coastal scenery",
       "Durdle Door natural arch is one of England's most photographed landmarks",
@@ -42080,7 +42840,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "17-79°F — four seasons New England coast",
+      "temp_range": "17-79\u00b0F \u2014 four seasons New England coast",
       "humidity": "Moderate",
       "rain": "Distributed year-round",
       "wind": "Can be strong off the Atlantic",
@@ -42124,7 +42884,7 @@
     ],
     "catches_off_guard": [
       "Portland has the most restaurants per capita of any US city",
-      "Lobster is freshest and cheapest here — eat it everywhere",
+      "Lobster is freshest and cheapest here \u2014 eat it everywhere",
       "The Old Port district is walkable and charming",
       "Portland Head Light is Maine's most iconic lighthouse",
       "Fall foliage (late Sep-mid Oct) is spectacular"
@@ -42238,7 +42998,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "41-80°F — Atlantic-influenced",
+      "temp_range": "41-80\u00b0F \u2014 Atlantic-influenced",
       "humidity": "Moderate; drier summer",
       "rain": "Wet winters; dry summers",
       "wind": "Atlantic breezes; cooler than inland",
@@ -42283,12 +43043,12 @@
     "catches_off_guard": [
       "Porto's port wine cellars in Vila Nova de Gaia are a must-visit",
       "The Ribeira district along the Douro is UNESCO World Heritage",
-      "Livraria Lello bookshop inspired Harry Potter — expect long queues",
-      "São Bento train station has 20,000 azulejo tiles",
+      "Livraria Lello bookshop inspired Harry Potter \u2014 expect long queues",
+      "S\u00e3o Bento train station has 20,000 azulejo tiles",
       "The Douro Valley wine region is a spectacular day trip"
     ],
     "packing_nudges": [
-      "Layers — temperature varies with sun/shade",
+      "Layers \u2014 temperature varies with sun/shade",
       "Comfortable walking shoes for steep hills",
       "Light rain jacket for winter",
       "Sunscreen for summer",
@@ -42396,7 +43156,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "40-82°F — Italian Riviera gem",
+      "temp_range": "40-82\u00b0F \u2014 Italian Riviera gem",
       "humidity": "Moderate (57-74%)",
       "rain": "Wetter than south Med; rainy autumn",
       "wind": "Sheltered harbor",
@@ -42434,16 +43194,16 @@
       "Aug"
     ],
     "catches_off_guard": [
-      "Tiny village — overwhelmed by cruise visitors",
+      "Tiny village \u2014 overwhelmed by cruise visitors",
       "Anchor in harbor, tender to shore",
-      "Everything is expensive — coffee can be €8",
+      "Everything is expensive \u2014 coffee can be \u20ac8",
       "Hike to San Fruttuoso monastery is spectacular",
       "Best visited early morning before crowds arrive"
     ],
     "packing_nudges": [
       "Comfortable walking shoes",
-      "Camera — photogenic beyond belief",
-      "Cash — some places don't take cards",
+      "Camera \u2014 photogenic beyond belief",
+      "Cash \u2014 some places don't take cards",
       "Light layers for sea breeze"
     ],
     "hazards": {
@@ -42549,7 +43309,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "67-86°F year-round warm",
+      "temp_range": "67-86\u00b0F year-round warm",
       "humidity": "Low to moderate",
       "rain": "Brief wet season Aug-Oct; dry otherwise",
       "wind": "Trade winds provide cooling",
@@ -42587,7 +43347,7 @@
     "catches_off_guard": [
       "Praia is the capital but less charming than Mindelo",
       "Plateau (old town) is walkable and has colonial architecture",
-      "Beach conditions vary — some have strong currents",
+      "Beach conditions vary \u2014 some have strong currents",
       "Cape Verdean cuisine is a unique Creole fusion",
       "Portuguese is official but Kriolu is spoken locally"
     ],
@@ -42596,7 +43356,7 @@
       "Sunscreen and hat",
       "Wind layer",
       "Comfortable walking shoes",
-      "Water bottle — stay hydrated"
+      "Water bottle \u2014 stay hydrated"
     ],
     "hazards": {
       "hurricane_zone": false
@@ -42700,7 +43460,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "66-94°F hot year-round",
+      "temp_range": "66-94\u00b0F hot year-round",
       "humidity": "Moderate to high",
       "rain": "Dry season Nov-Apr; wet May-Oct",
       "wind": "Moderate; nortes (cold fronts) in winter",
@@ -42747,10 +43507,10 @@
       "Aug"
     ],
     "catches_off_guard": [
-      "Progreso is the port for Mérida and Chichén Itzá — both require transport",
-      "Chichén Itzá is a 2+ hour drive each way — start early",
-      "Cenotes (natural sinkholes) are unique to the Yucatán",
-      "Mérida is a beautiful colonial city worth the 45-min drive",
+      "Progreso is the port for M\u00e9rida and Chich\u00e9n Itz\u00e1 \u2014 both require transport",
+      "Chich\u00e9n Itz\u00e1 is a 2+ hour drive each way \u2014 start early",
+      "Cenotes (natural sinkholes) are unique to the Yucat\u00e1n",
+      "M\u00e9rida is a beautiful colonial city worth the 45-min drive",
       "The beach pier is one of the longest in the world (4 miles)"
     ],
     "packing_nudges": [
@@ -42762,7 +43522,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Sep",
         "Oct"
@@ -42867,7 +43627,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "73-92°F — Pacific Costa Rica",
+      "temp_range": "73-92\u00b0F \u2014 Pacific Costa Rica",
       "humidity": "Lower dry season; high wet",
       "rain": "Dry season Dec-Apr; wet May-Nov",
       "wind": "Moderate; papagayo winds in dry season",
@@ -42915,7 +43675,7 @@
       "Puerto Caldera is the Pacific cruise port for Costa Rica",
       "Manuel Antonio National Park (2 hours) has monkeys and beaches",
       "Arenal Volcano is a popular but long day trip (3+ hours)",
-      "Costa Rica's biodiversity is extraordinary — sloths, toucans, monkeys",
+      "Costa Rica's biodiversity is extraordinary \u2014 sloths, toucans, monkeys",
       "Pura Vida is the national motto and way of life"
     ],
     "packing_nudges": [
@@ -42927,7 +43687,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "May 15 – Nov 30 (East Pacific)",
+      "hurricane_season": "May 15 \u2013 Nov 30 (East Pacific)",
       "peak_risk_months": [
         "Aug",
         "Sep",
@@ -43033,7 +43793,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "72-87°F year-round",
+      "temp_range": "72-87\u00b0F year-round",
       "humidity": "Very high (82-88%)",
       "rain": "Rain nearly year-round; driest Feb-Apr",
       "wind": "Light; mountains shelter",
@@ -43074,18 +43834,18 @@
       "One of wettest Caribbean locations",
       "Tortuguero turtles accessible by boat",
       "Sloth and monkey sightings common",
-      "City limited — excursions recommended",
+      "City limited \u2014 excursions recommended",
       "Veragua Rainforest aerial tram popular"
     ],
     "packing_nudges": [
-      "Waterproof rain jacket — essential",
+      "Waterproof rain jacket \u2014 essential",
       "Heavy-duty bug repellent",
       "Quick-dry clothing",
       "Waterproof bag for electronics"
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Sep",
         "Oct"
@@ -43191,9 +43951,9 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "30-77°F — Patagonian steppe coast",
-      "humidity": "Low — semi-arid",
-      "rain": "Very little year-round — Patagonian desert",
+      "temp_range": "30-77\u00b0F \u2014 Patagonian steppe coast",
+      "humidity": "Low \u2014 semi-arid",
+      "rain": "Very little year-round \u2014 Patagonian desert",
       "wind": "Strong and persistent Patagonian winds",
       "daylight": "9-15.5 hours (Southern Hemisphere)"
     },
@@ -43233,10 +43993,10 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "Southern right whales come to Golfo Nuevo Jun-Dec — spectacular",
+      "Southern right whales come to Golfo Nuevo Jun-Dec \u2014 spectacular",
       "Punta Tombo penguin colony is the largest in South America (but 100+ miles away)",
-      "Península Valdés is a UNESCO site with sea lions, elephant seals, orcas",
-      "The wind is Patagonia's defining feature — it never stops",
+      "Pen\u00ednsula Vald\u00e9s is a UNESCO site with sea lions, elephant seals, orcas",
+      "The wind is Patagonia's defining feature \u2014 it never stops",
       "Welsh settlement history is visible in tea houses and place names"
     ],
     "packing_nudges": [
@@ -43348,7 +44108,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "36-67°F — Chilean Lake District",
+      "temp_range": "36-67\u00b0F \u2014 Chilean Lake District",
       "humidity": "High; frequent rain",
       "rain": "Wet year-round; wettest May-Jul",
       "wind": "Moderate; sheltered by lakes and volcanoes",
@@ -43387,9 +44147,9 @@
     "avoid_months": [],
     "catches_off_guard": [
       "Osorno Volcano dominates the skyline on clear days",
-      "Angelmó fish market and craft market are the top port attractions",
+      "Angelm\u00f3 fish market and craft market are the top port attractions",
       "Puerto Varas (nearby) is the more scenic town on Lake Llanquihue",
-      "Rain is frequent year-round — waterproofs essential",
+      "Rain is frequent year-round \u2014 waterproofs essential",
       "German colonial influence is evident in architecture and kuchen (cake)"
     ],
     "packing_nudges": [
@@ -43401,7 +44161,7 @@
     ],
     "hazards": {
       "hurricane_zone": false,
-      "note": "Rain is frequent year-round — waterproofs essential."
+      "note": "Rain is frequent year-round \u2014 waterproofs essential."
     },
     "cruise_seasons": {
       "high": [
@@ -43502,7 +44262,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "61-90°F tropical resort coast",
+      "temp_range": "61-90\u00b0F tropical resort coast",
       "humidity": "Low dry season; high wet season",
       "rain": "Dry Nov-May; rainy Jun-Oct",
       "wind": "Light; occasional chubascos (squalls) in summer",
@@ -43550,22 +44310,22 @@
       "Sep"
     ],
     "catches_off_guard": [
-      "The Malecón boardwalk has excellent public art sculptures",
+      "The Malec\u00f3n boardwalk has excellent public art sculptures",
       "Whale watching (Dec-Mar) in Banderas Bay is outstanding",
-      "Old Town (Zona Romántica) has the best restaurants and atmosphere",
-      "Summer rain usually falls in late afternoon — mornings are often clear",
+      "Old Town (Zona Rom\u00e1ntica) has the best restaurants and atmosphere",
+      "Summer rain usually falls in late afternoon \u2014 mornings are often clear",
       "Los Arcos Marine Park offers great snorkeling from boat tours"
     ],
     "packing_nudges": [
       "Light beach clothing",
       "Sunscreen and hat",
       "Rain jacket for summer visits",
-      "Comfortable walking shoes for Malecón",
+      "Comfortable walking shoes for Malec\u00f3n",
       "Water shoes for rocky beach entries"
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "May 15 – Nov 30 (East Pacific)",
+      "hurricane_season": "May 15 \u2013 Nov 30 (East Pacific)",
       "peak_risk_months": [
         "Aug",
         "Sep",
@@ -43671,10 +44431,10 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "29-58°F — Patagonian cold year-round",
+      "temp_range": "29-58\u00b0F \u2014 Patagonian cold year-round",
       "humidity": "Moderate to high",
       "rain": "Distributed; drier in summer",
-      "wind": "Extreme and persistent — strongest city winds in the world",
+      "wind": "Extreme and persistent \u2014 strongest city winds in the world",
       "daylight": "7.5-17 hours (extreme seasonal variation)"
     },
     "best_months_for": {
@@ -43712,7 +44472,7 @@
       "Aug"
     ],
     "catches_off_guard": [
-      "Wind is the defining feature — gusts can knock you off balance",
+      "Wind is the defining feature \u2014 gusts can knock you off balance",
       "Magdalena Island penguin colony is a highlight (Nov-Mar)",
       "The Strait of Magellan is historically significant and scenic",
       "Torres del Paine is a full-day excursion (5 hours each way)",
@@ -43720,7 +44480,7 @@
     ],
     "packing_nudges": [
       "Heavy windproof jacket essential",
-      "Warm layers — multiple thin layers work best",
+      "Warm layers \u2014 multiple thin layers work best",
       "Warm hat, gloves, neck gaiter",
       "Sturdy boots",
       "Sunglasses for wind protection"
@@ -43827,7 +44587,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "39-82°F — South American Riviera",
+      "temp_range": "39-82\u00b0F \u2014 South American Riviera",
       "humidity": "Moderate",
       "rain": "Evenly distributed year-round",
       "wind": "Strong along the coast; can be bracing",
@@ -43863,9 +44623,9 @@
     "catches_off_guard": [
       "Punta del Este is South America's most glamorous beach resort",
       "The Hand in the Sand sculpture is the iconic photo spot",
-      "Casapueblo (artist Carlos Páez Vilaró's home/museum) is stunning at sunset",
+      "Casapueblo (artist Carlos P\u00e1ez Vilar\u00f3's home/museum) is stunning at sunset",
       "Summer (Dec-Feb) brings Argentine and Brazilian vacationers",
-      "Off-season the town is very quiet — many restaurants close"
+      "Off-season the town is very quiet \u2014 many restaurants close"
     ],
     "packing_nudges": [
       "Beach wear for summer",
@@ -43976,7 +44736,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "73-92°F — Pacific Costa Rica",
+      "temp_range": "73-92\u00b0F \u2014 Pacific Costa Rica",
       "humidity": "Lower dry season; high wet",
       "rain": "Dry Dec-Apr; wet May-Nov",
       "wind": "Moderate",
@@ -44021,10 +44781,10 @@
     ],
     "catches_off_guard": [
       "Puntarenas is an alternative Pacific port to Puerto Caldera",
-      "The town itself is a narrow peninsula — very walkable",
-      "Carara National Park is 1 hour away — scarlet macaws guaranteed",
-      "Crocodile Bridge on the Tárcoles River is a famous stop",
-      "San José (capital) is 1.5 hours inland"
+      "The town itself is a narrow peninsula \u2014 very walkable",
+      "Carara National Park is 1 hour away \u2014 scarlet macaws guaranteed",
+      "Crocodile Bridge on the T\u00e1rcoles River is a famous stop",
+      "San Jos\u00e9 (capital) is 1.5 hours inland"
     ],
     "packing_nudges": [
       "Light breathable clothing",
@@ -44035,7 +44795,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "May 15 – Nov 30 (East Pacific)",
+      "hurricane_season": "May 15 \u2013 Nov 30 (East Pacific)",
       "peak_risk_months": [
         "Aug",
         "Sep",
@@ -44141,7 +44901,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "3-76°F — four extreme seasons",
+      "temp_range": "3-76\u00b0F \u2014 four extreme seasons",
       "humidity": "Moderate; variable",
       "rain": "Distributed year-round; snow Nov-Apr",
       "wind": "Can be strong; river valley funneling",
@@ -44180,11 +44940,11 @@
       "Feb"
     ],
     "catches_off_guard": [
-      "Old Québec is a UNESCO World Heritage site — the only walled city in North America",
-      "Château Frontenac is the world's most-photographed hotel",
+      "Old Qu\u00e9bec is a UNESCO World Heritage site \u2014 the only walled city in North America",
+      "Ch\u00e2teau Frontenac is the world's most-photographed hotel",
       "Fall foliage (late Sep-mid Oct) is spectacular along the St. Lawrence",
-      "The city is very French — expect French as the primary language",
-      "Île d'Orléans is a bucolic island with farms and artisan shops"
+      "The city is very French \u2014 expect French as the primary language",
+      "\u00cele d'Orl\u00e9ans is a bucolic island with farms and artisan shops"
     ],
     "packing_nudges": [
       "Heavy warm layers for fall/winter/spring",
@@ -44295,7 +45055,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "28-85°F — gateway to Byzantine mosaics",
+      "temp_range": "28-85\u00b0F \u2014 gateway to Byzantine mosaics",
       "humidity": "Moderate to high (58-82%)",
       "rain": "Distributed year-round; slightly drier summer",
       "wind": "Cold Bura in winter; sea breezes summer",
@@ -44335,9 +45095,9 @@
     "catches_off_guard": [
       "Byzantine mosaics are UNESCO-listed and breathtaking",
       "Ravenna was capital of Western Roman Empire",
-      "Dante's tomb is here — he died in exile",
+      "Dante's tomb is here \u2014 he died in exile",
       "Marina di Ravenna beach is accessible by bus",
-      "Winters can be foggy and cold — dress warmly"
+      "Winters can be foggy and cold \u2014 dress warmly"
     ],
     "packing_nudges": [
       "Comfortable walking shoes",
@@ -44448,7 +45208,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "71-87°F year-round tropical",
+      "temp_range": "71-87\u00b0F year-round tropical",
       "humidity": "High year-round; wettest Mar-Jul",
       "rain": "Wet season Mar-Jul; dry Aug-Feb",
       "wind": "Trade winds; sea breezes",
@@ -44484,9 +45244,9 @@
       "Jul"
     ],
     "catches_off_guard": [
-      "Recife is called the Venice of Brazil — built on rivers and canals",
-      "Olinda (nearby) is a gorgeous colonial town — UNESCO site",
-      "Shark attacks are a concern at some beaches — check warnings",
+      "Recife is called the Venice of Brazil \u2014 built on rivers and canals",
+      "Olinda (nearby) is a gorgeous colonial town \u2014 UNESCO site",
+      "Shark attacks are a concern at some beaches \u2014 check warnings",
       "The reefs that give Recife its name create natural pools",
       "Frevo dance and music are unique to Pernambuco"
     ],
@@ -44599,10 +45359,10 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "36-57°F; cool year-round, 'warm' summer is only 55°F",
-      "humidity": "Moderate to High (72-77%) — damp island climate",
+      "temp_range": "36-57\u00b0F; cool year-round, 'warm' summer is only 55\u00b0F",
+      "humidity": "Moderate to High (72-77%) \u2014 damp island climate",
       "rain": "Frequent drizzle/rain year-round; weather changes rapidly",
-      "wind": "Extremely windy — sustained 25+ mph common, gusts much higher",
+      "wind": "Extremely windy \u2014 sustained 25+ mph common, gusts much higher",
       "daylight": "4-21 hours; midnight sun Jun-Jul, near-darkness Dec-Jan"
     },
     "best_months_for": {
@@ -44653,15 +45413,15 @@
       "Feb"
     ],
     "catches_off_guard": [
-      "Wind is relentless and shockingly strong — 40+ mph is normal",
-      "July 'summer' high is only 57°F — this is not beach weather",
-      "Weather changes every 10 minutes — sun to rain to wind",
+      "Wind is relentless and shockingly strong \u2014 40+ mph is normal",
+      "July 'summer' high is only 57\u00b0F \u2014 this is not beach weather",
+      "Weather changes every 10 minutes \u2014 sun to rain to wind",
       "Extremely expensive (most expensive in Europe)",
       "Blue Lagoon requires advance booking (sells out weeks ahead)",
       "Wind can literally knock you over or blow open car doors"
     ],
     "packing_nudges": [
-      "Windproof waterproof jacket (essential — wind penetrates everything)",
+      "Windproof waterproof jacket (essential \u2014 wind penetrates everything)",
       "Warm layers including fleece/wool even in July",
       "Waterproof pants for outdoor excursions",
       "Sturdy waterproof boots",
@@ -44771,7 +45531,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "44-88°F — sunny Greek island",
+      "temp_range": "44-88\u00b0F \u2014 sunny Greek island",
       "humidity": "Low to moderate (35-71%)",
       "rain": "Very dry May-Sep; wet winters",
       "wind": "Meltemi Jul-Aug; generally breezy",
@@ -44807,15 +45567,15 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "Medieval Old Town is UNESCO — best-preserved in Mediterranean",
+      "Medieval Old Town is UNESCO \u2014 best-preserved in Mediterranean",
       "Lindos acropolis is stunning but steep (donkey ride available)",
       "Valley of Butterflies is seasonal (Jun-Sep only)",
       "Meltemi wind makes east coast beaches choppy in summer",
-      "Colossus of Rhodes is long gone — don't expect to see it"
+      "Colossus of Rhodes is long gone \u2014 don't expect to see it"
     ],
     "packing_nudges": [
       "Comfortable shoes for cobblestones",
-      "Sunscreen — UV is intense",
+      "Sunscreen \u2014 UV is intense",
       "Hat for ruins visits",
       "Cash for Old Town shops"
     ],
@@ -44922,7 +45682,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "16-73°F — Art Nouveau capital",
+      "temp_range": "16-73\u00b0F \u2014 Art Nouveau capital",
       "humidity": "Moderate to high (61-88%)",
       "rain": "Year-round; wetter summer",
       "wind": "Baltic influence",
@@ -44961,11 +45721,11 @@
       "Feb"
     ],
     "catches_off_guard": [
-      "Art Nouveau district has 800+ buildings — Europe's finest collection",
+      "Art Nouveau district has 800+ buildings \u2014 Europe's finest collection",
       "Central Market in former Zeppelin hangars is enormous",
       "Old Town and Art Nouveau district are separate areas",
       "Riga Black Balsam (herbal liqueur) is acquired taste",
-      "Jūrmala beach resort is 30 min by train"
+      "J\u016brmala beach resort is 30 min by train"
     ],
     "packing_nudges": [
       "Warm layers",
@@ -45076,7 +45836,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "62-85°F year-round warm",
+      "temp_range": "62-85\u00b0F year-round warm",
       "humidity": "High; drier Jun-Aug",
       "rain": "Wetter Dec-Mar; drier Jun-Aug",
       "wind": "Light; sea breezes",
@@ -45116,7 +45876,7 @@
     "avoid_months": [],
     "catches_off_guard": [
       "Carnival (Feb/Mar) transforms the city but hotel prices triple",
-      "Christ the Redeemer is often in clouds — go early morning for best views",
+      "Christ the Redeemer is often in clouds \u2014 go early morning for best views",
       "Copacabana and Ipanema are iconic but watch belongings closely",
       "Summer rain (Dec-Mar) can cause dangerous mudslides in favelas",
       "The view from Sugarloaf at sunset is unmissable"
@@ -45230,7 +45990,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "73-89°F year-round",
+      "temp_range": "73-89\u00b0F year-round",
       "humidity": "Moderate to high (74-80%)",
       "rain": "Drier Mar-Jun; wetter Oct-Jan",
       "wind": "Trades; calmer May-Sep",
@@ -45267,21 +46027,21 @@
       "Nov"
     ],
     "catches_off_guard": [
-      "Rainy season opposite many Caribbean islands — wettest Oct-Jan",
+      "Rainy season opposite many Caribbean islands \u2014 wettest Oct-Jan",
       "Mesoamerican Barrier Reef is world's second largest",
       "Taxis charge per person",
       "West End differs from cruise port area",
       "Tap water not safe to drink"
     ],
     "packing_nudges": [
-      "Reef-safe sunscreen — enforced",
+      "Reef-safe sunscreen \u2014 enforced",
       "Water shoes for coral",
-      "Cash — many places no cards",
+      "Cash \u2014 many places no cards",
       "Bug repellent for jungle"
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Sep",
         "Oct",
@@ -45388,7 +46148,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "26-71°F — Hanseatic Baltic city",
+      "temp_range": "26-71\u00b0F \u2014 Hanseatic Baltic city",
       "humidity": "Moderate to high (69-87%)",
       "rain": "Year-round; drier spring",
       "wind": "Baltic winds",
@@ -45426,9 +46186,9 @@
       "Feb"
     ],
     "catches_off_guard": [
-      "Historic Hanseatic League city — brick Gothic architecture",
-      "Warnemünde beach resort is 15 min away",
-      "University town — lively student atmosphere",
+      "Historic Hanseatic League city \u2014 brick Gothic architecture",
+      "Warnem\u00fcnde beach resort is 15 min away",
+      "University town \u2014 lively student atmosphere",
       "Berlin day trip requires early start",
       "Marienkirche astronomical clock is medieval marvel"
     ],
@@ -45541,7 +46301,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "33-75°F geothermal wonderland",
+      "temp_range": "33-75\u00b0F geothermal wonderland",
       "humidity": "Moderate to high",
       "rain": "Distributed year-round",
       "wind": "Light; sheltered inland location",
@@ -45582,7 +46342,7 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "The sulfur smell is inescapable — you get used to it quickly",
+      "The sulfur smell is inescapable \u2014 you get used to it quickly",
       "Te Puia and Whakarewarewa are competing geothermal parks",
       "Maori cultural performances (hangi feast) are a must-do",
       "The Redwoods Treewalk is spectacular day or night",
@@ -45597,7 +46357,7 @@
     ],
     "hazards": {
       "hurricane_zone": false,
-      "note": "The sulfur smell is inescapable — you get used to it quickly."
+      "note": "The sulfur smell is inescapable \u2014 you get used to it quickly."
     },
     "cruise_seasons": {
       "high": [
@@ -45698,7 +46458,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "72-89°F year-round",
+      "temp_range": "72-89\u00b0F year-round",
       "humidity": "Moderate (68-76%)",
       "rain": "Drier Jan-Apr; wetter Jul-Nov",
       "wind": "Persistent trades",
@@ -45730,9 +46490,9 @@
     ],
     "catches_off_guard": [
       "Royal Caribbean private beach club",
-      "Curated experience — not independent exploration",
+      "Curated experience \u2014 not independent exploration",
       "All charges to SeaPass",
-      "Limited capacity — feels less crowded than public ports",
+      "Limited capacity \u2014 feels less crowded than public ports",
       "Antiguan climate applies"
     ],
     "packing_nudges": [
@@ -45743,7 +46503,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Sep",
         "Oct"
@@ -45849,7 +46609,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "70-90°F year-round",
+      "temp_range": "70-90\u00b0F year-round",
       "humidity": "Moderate to high (74-82%)",
       "rain": "Brief showers; heaviest Jun-Oct",
       "wind": "Trades; strongest Dec-Apr",
@@ -45887,14 +46647,14 @@
       "Reef snorkeling nearby is excellent"
     ],
     "packing_nudges": [
-      "Reef-safe sunscreen — required by law",
+      "Reef-safe sunscreen \u2014 required by law",
       "Waterproof phone case",
       "Water shoes",
       "No cash needed"
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Sep",
         "Oct"
@@ -46000,7 +46760,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "65-90°F year-round",
+      "temp_range": "65-90\u00b0F year-round",
       "humidity": "Moderate to high (71-79%)",
       "rain": "Brief showers; heaviest Jun-Oct",
       "wind": "Easterly trades",
@@ -46032,7 +46792,7 @@
     ],
     "catches_off_guard": [
       "Royal Caribbean private beach club near Nassau",
-      "Curated experience — not downtown Nassau",
+      "Curated experience \u2014 not downtown Nassau",
       "All charges to SeaPass",
       "Nassau Bahamas climate applies",
       "Less crowded than public Nassau beaches"
@@ -46045,7 +46805,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Sep",
         "Oct"
@@ -46151,8 +46911,8 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "52-102°F desert coastal range",
-      "humidity": "Very low — Red Sea desert climate",
+      "temp_range": "52-102\u00b0F desert coastal range",
+      "humidity": "Very low \u2014 Red Sea desert climate",
       "rain": "Essentially zero rainfall",
       "wind": "Can be strong and sandy; khamsin winds in spring",
       "daylight": "10.5-13.5 hours seasonal"
@@ -46195,11 +46955,11 @@
       "Aug"
     ],
     "catches_off_guard": [
-      "Luxor (Valley of the Kings) is a 3-hour drive — plan for extreme heat",
+      "Luxor (Valley of the Kings) is a 3-hour drive \u2014 plan for extreme heat",
       "Red Sea coral reefs are spectacular year-round",
-      "The desert sun is brutal — dehydration sneaks up fast",
+      "The desert sun is brutal \u2014 dehydration sneaks up fast",
       "Khamsin sandstorms (Mar-May) can ground excursions",
-      "Safaga itself has minimal tourist infrastructure — it's a port town"
+      "Safaga itself has minimal tourist infrastructure \u2014 it's a port town"
     ],
     "packing_nudges": [
       "Strong sunscreen SPF 50+",
@@ -46310,7 +47070,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "0-74°F — deep fjord climate",
+      "temp_range": "0-74\u00b0F \u2014 deep fjord climate",
       "humidity": "Moderate; cold winters",
       "rain": "Distributed; snow Oct-Apr",
       "wind": "Sheltered in the fjord; exposed on hilltops",
@@ -46350,14 +47110,14 @@
       "Mar"
     ],
     "catches_off_guard": [
-      "Saguenay Fjord is one of the world's longest — dramatic scenery",
+      "Saguenay Fjord is one of the world's longest \u2014 dramatic scenery",
       "Beluga whales and other species feed at the fjord mouth (Tadoussac)",
       "The village of La Baie has the cruise terminal",
       "Fall foliage along the fjord is spectacular",
-      "Winter temperatures can drop to -40°F — cruise season is summer only"
+      "Winter temperatures can drop to -40\u00b0F \u2014 cruise season is summer only"
     ],
     "packing_nudges": [
-      "Warm layers essential — even summer evenings are cool",
+      "Warm layers essential \u2014 even summer evenings are cool",
       "Waterproof jacket",
       "Binoculars for whale watching",
       "Warm hat and fleece",
@@ -46465,7 +47225,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "13-70°F — Bay of Fundy maritime",
+      "temp_range": "13-70\u00b0F \u2014 Bay of Fundy maritime",
       "humidity": "Moderate to high; foggy",
       "rain": "Distributed; fog common summer",
       "wind": "Can be strong; bay funneling effect",
@@ -46506,8 +47266,8 @@
       "The Reversing Falls are caused by the Bay of Fundy's extreme tides",
       "Saint John City Market is the oldest continuing farmers market in Canada",
       "The Bay of Fundy has the highest tides in the world (53 feet)",
-      "Fog is very common — the Fundy coast is one of the foggiest in the world",
-      "The city is built on hills — expect some steep walking"
+      "Fog is very common \u2014 the Fundy coast is one of the foggiest in the world",
+      "The city is built on hills \u2014 expect some steep walking"
     ],
     "packing_nudges": [
       "Warm layers even in summer",
@@ -46618,7 +47378,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "74-86°F year-round tropical",
+      "temp_range": "74-86\u00b0F year-round tropical",
       "humidity": "High year-round",
       "rain": "Dry Jan-May; wet Jul-Nov",
       "wind": "Trade winds; typhoon exposure",
@@ -46659,7 +47419,7 @@
       "Oct"
     ],
     "catches_off_guard": [
-      "Saipan has significant WWII history — Banzai Cliff and Suicide Cliff",
+      "Saipan has significant WWII history \u2014 Banzai Cliff and Suicide Cliff",
       "The Grotto is one of the world's best cave dives",
       "Managaha Island is a short boat ride for pristine snorkeling",
       "Japanese tourists have historically dominated tourism here",
@@ -46674,7 +47434,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jul – Nov (Western Pacific typhoon season)",
+      "hurricane_season": "Jul \u2013 Nov (Western Pacific typhoon season)",
       "peak_risk_months": [
         "Aug",
         "Sep",
@@ -46780,7 +47540,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "64-92°F coastal desert with monsoon twist",
+      "temp_range": "64-92\u00b0F coastal desert with monsoon twist",
       "humidity": "Low most of year; high during Khareef (Jul-Aug)",
       "rain": "Khareef monsoon Jul-Aug brings drizzle and green hills; dry otherwise",
       "wind": "Monsoon winds Jul-Aug",
@@ -46820,10 +47580,10 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "Khareef monsoon (Jul-Aug) transforms the desert green — unique phenomenon",
+      "Khareef monsoon (Jul-Aug) transforms the desert green \u2014 unique phenomenon",
       "This is the only place in Arabia with a monsoon season",
       "Frankincense has been traded here for millennia",
-      "Salalah is very different from northern Oman — more tropical feel",
+      "Salalah is very different from northern Oman \u2014 more tropical feel",
       "The monsoon brings cooler temperatures but gray, misty conditions"
     ],
     "packing_nudges": [
@@ -46935,7 +47695,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "69-87°F year-round tropical",
+      "temp_range": "69-87\u00b0F year-round tropical",
       "humidity": "High year-round",
       "rain": "Wetter Apr-Jul; drier Sep-Jan",
       "wind": "Trade winds; sea breezes",
@@ -46977,10 +47737,10 @@
     ],
     "catches_off_guard": [
       "Salvador's Pelourinho (historic center) is UNESCO World Heritage",
-      "Afro-Brazilian culture is strongest here — capoeira, candomblé, cuisine",
+      "Afro-Brazilian culture is strongest here \u2014 capoeira, candombl\u00e9, cuisine",
       "Carnival in Salvador is the world's largest street party",
       "The Lacerda Elevator connects upper and lower city",
-      "Acarajé (street food) is a must-try — unique to Bahia"
+      "Acaraj\u00e9 (street food) is a must-try \u2014 unique to Bahia"
     ],
     "packing_nudges": [
       "Light breathable clothing",
@@ -47091,7 +47851,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "70-89°F year-round",
+      "temp_range": "70-89\u00b0F year-round",
       "humidity": "Moderate to high (74-81%)",
       "rain": "Wetter than south DR",
       "wind": "Moderate trades",
@@ -47134,20 +47894,20 @@
     ],
     "catches_off_guard": [
       "Humpback whale season Jan-Mar is spectacular",
-      "El Limón waterfall requires horseback or muddy hike",
+      "El Lim\u00f3n waterfall requires horseback or muddy hike",
       "More rural than Punta Cana",
       "Tender port from larger ships",
-      "Playa Rincón among DR's best beaches"
+      "Playa Rinc\u00f3n among DR's best beaches"
     ],
     "packing_nudges": [
       "Waterproof camera for whales",
       "Sturdy shoes for waterfall",
       "Motion sickness remedy for boats",
-      "Cash — limited card acceptance"
+      "Cash \u2014 limited card acceptance"
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Sep",
         "Oct"
@@ -47253,8 +48013,8 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "66-78°F; near-perfect weather year-round, rarely rains",
-      "humidity": "Moderate (61-69%) — comfortable Mediterranean climate",
+      "temp_range": "66-78\u00b0F; near-perfect weather year-round, rarely rains",
+      "humidity": "Moderate (61-69%) \u2014 comfortable Mediterranean climate",
       "rain": "Virtually none Apr-Oct; light rain Dec-Mar",
       "wind": "Light ocean breezes keep temperatures mild",
       "daylight": "10-14 hours; sunny 266 days per year"
@@ -47298,10 +48058,10 @@
     "avoid_months": [],
     "catches_off_guard": [
       "May-June 'June Gloom' brings marine layer (cool overcast mornings)",
-      "Ocean water is cold year-round (60-70°F) — not Caribbean warmth",
-      "Port is right downtown — easy walk to Gaslamp Quarter",
-      "Tijuana is close but border crossing takes time — not ideal for port day",
-      "Locals think 75°F is 'hot' — bring layers for indoors",
+      "Ocean water is cold year-round (60-70\u00b0F) \u2014 not Caribbean warmth",
+      "Port is right downtown \u2014 easy walk to Gaslamp Quarter",
+      "Tijuana is close but border crossing takes time \u2014 not ideal for port day",
+      "Locals think 75\u00b0F is 'hot' \u2014 bring layers for indoors",
       "Beach water is chilly even in summer (wetsuit for extended swimming)"
     ],
     "packing_nudges": [
@@ -47415,8 +48175,8 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "57-70°F; cool year-round, famous fog in summer",
-      "humidity": "Moderate to High (70-77%) — fog creates dampness",
+      "temp_range": "57-70\u00b0F; cool year-round, famous fog in summer",
+      "humidity": "Moderate to High (70-77%) \u2014 fog creates dampness",
       "rain": "Rainy Nov-Mar; dry Apr-Oct but fog replaces rain in summer",
       "wind": "Often windy and chilly, especially near water",
       "daylight": "10-15 hours; fog can obscure sun even when 'sunny'"
@@ -47455,12 +48215,12 @@
       "Aug"
     ],
     "catches_off_guard": [
-      "Summer is the COLDEST and FOGGIEST season (60-66°F with fog)",
+      "Summer is the COLDEST and FOGGIEST season (60-66\u00b0F with fog)",
       "Mark Twain quote: 'Coldest winter I ever spent was a summer in San Francisco'",
       "Fog can be so thick you can't see Golden Gate Bridge in Jul-Aug",
       "Warmest months are Sep-Oct, not summer",
       "Layers are absolutely essential year-round",
-      "Wind chill makes 65°F feel like 50°F"
+      "Wind chill makes 65\u00b0F feel like 50\u00b0F"
     ],
     "packing_nudges": [
       "Warm jacket even in July/August (seriously)",
@@ -47573,7 +48333,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "73-89°F year-round",
+      "temp_range": "73-89\u00b0F year-round",
       "humidity": "Moderate to high (71-79%)",
       "rain": "Afternoon showers common; heaviest Aug-Nov",
       "wind": "Trade winds steady",
@@ -47629,7 +48389,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Aug",
         "Sep",
@@ -47736,7 +48496,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "74-90°F year-round",
+      "temp_range": "74-90\u00b0F year-round",
       "humidity": "Moderate to high (74-81%)",
       "rain": "Dry Dec-Apr; moderate wet season",
       "wind": "Strong Dec-Mar",
@@ -47774,7 +48534,7 @@
     ],
     "catches_off_guard": [
       "Tayrona National Park spectacular but needs transport",
-      "Sierra Nevada — world's highest coastal mountain",
+      "Sierra Nevada \u2014 world's highest coastal mountain",
       "Ciudad Perdida trek not feasible from cruise",
       "Less touristy than Cartagena",
       "Strong Dec-Mar winds make beaches choppy"
@@ -47787,7 +48547,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Sep",
         "Oct"
@@ -47893,8 +48653,8 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "57-84°F; hot dry summers, mild wet winters",
-      "humidity": "Low to Moderate (57-72%) — dry in summer, less humid than mainland",
+      "temp_range": "57-84\u00b0F; hot dry summers, mild wet winters",
+      "humidity": "Low to Moderate (57-72%) \u2014 dry in summer, less humid than mainland",
       "rain": "Virtually no rain Jun-Aug; wettest Nov-Feb",
       "wind": "Meltemi winds can be strong Jun-Sep, especially afternoons",
       "daylight": "9-15 hours; stunning sunsets year-round"
@@ -47941,12 +48701,12 @@
       "Aug"
     ],
     "catches_off_guard": [
-      "Tender port — ships anchor offshore, tenders can be slow/delayed",
+      "Tender port \u2014 ships anchor offshore, tenders can be slow/delayed",
       "Cable car from port has massive queues when multiple ships in port",
       "Oia sunset viewing area gets dangerously packed in summer",
       "July-August winds can make tendering rough or impossible",
       "Caldera views come with steep steps and uneven paths",
-      "August is insanely crowded — overtourism is severe"
+      "August is insanely crowded \u2014 overtourism is severe"
     ],
     "packing_nudges": [
       "Very comfortable walking shoes (cobblestones and 300+ steps)",
@@ -48059,7 +48819,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "59-84°F subtropical coastal",
+      "temp_range": "59-84\u00b0F subtropical coastal",
       "humidity": "High year-round",
       "rain": "Wetter Dec-Mar; drier Jun-Aug",
       "wind": "Light; sea breezes",
@@ -48095,8 +48855,8 @@
     "catches_off_guard": [
       "Santos has the longest beachfront garden in the world",
       "The Coffee Museum reflects the city's history as coffee export capital",
-      "São Paulo is 1 hour inland — a huge, vibrant megacity",
-      "Pelé played for Santos FC — visit the stadium museum",
+      "S\u00e3o Paulo is 1 hour inland \u2014 a huge, vibrant megacity",
+      "Pel\u00e9 played for Santos FC \u2014 visit the stadium museum",
       "The port area has been revitalized with restaurants and culture"
     ],
     "packing_nudges": [
@@ -48208,7 +48968,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "34-65°F — cool maritime year-round",
+      "temp_range": "34-65\u00b0F \u2014 cool maritime year-round",
       "humidity": "High; frequent rain",
       "rain": "Frequent year-round; slightly drier spring",
       "wind": "Can be very strong; exposed coasts",
@@ -48249,11 +49009,11 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "Scottish weather is famously unpredictable — prepare for everything",
+      "Scottish weather is famously unpredictable \u2014 prepare for everything",
       "Midges (biting insects) plague the Highlands Jun-Sep",
       "Whisky distillery tours are a cultural highlight",
       "Edinburgh Castle dominates the skyline from any angle",
-      "The Highlands are vast and sparsely populated — excursions take time"
+      "The Highlands are vast and sparsely populated \u2014 excursions take time"
     ],
     "packing_nudges": [
       "Warm waterproof layers essential",
@@ -48364,8 +49124,8 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "46-76°F; mild year-round, wet winters, dry summers",
-      "humidity": "Moderate to High (61-80%) — damp in winter",
+      "temp_range": "46-76\u00b0F; mild year-round, wet winters, dry summers",
+      "humidity": "Moderate to High (61-80%) \u2014 damp in winter",
       "rain": "Rainy season Nov-Mar; summers are sunny and dry",
       "wind": "Light breezes; protected by mountains",
       "daylight": "8-16 hours; long summer evenings, dark winter afternoons"
@@ -48407,9 +49167,9 @@
     "catches_off_guard": [
       "It drizzles constantly Nov-Mar, but locals don't use umbrellas",
       "Summer cruise season is also the ONLY nice weather (Jun-Sep)",
-      "July-August can be warm (75°F) but locals call it a 'heat wave'",
-      "Port is right in the city — easy walking access",
-      "Coffee culture is real — Starbucks everywhere (birthplace)",
+      "July-August can be warm (75\u00b0F) but locals call it a 'heat wave'",
+      "Port is right in the city \u2014 easy walking access",
+      "Coffee culture is real \u2014 Starbucks everywhere (birthplace)",
       "Layers are essential even in summer (mornings cool, afternoons warm)"
     ],
     "packing_nudges": [
@@ -48523,8 +49283,8 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "28-64°F; cruise season May-Sep peaks at 55-65°F",
-      "humidity": "Moderate to High (68-78%) — damp coastal climate",
+      "temp_range": "28-64\u00b0F; cruise season May-Sep peaks at 55-65\u00b0F",
+      "humidity": "Moderate to High (68-78%) \u2014 damp coastal climate",
       "rain": "Frequent drizzle and showers; wettest Jul-Sep during cruise season",
       "wind": "Breezy coastal winds; can be chilly on water",
       "daylight": "18-19 hours in Jun; only 6 hours in Dec"
@@ -48572,9 +49332,9 @@
       "Mar"
     ],
     "catches_off_guard": [
-      "Rain is common even in summer — waterproof layers essential",
-      "60°F feels colder on the water with wind chill",
-      "Weather changes rapidly — dress in layers",
+      "Rain is common even in summer \u2014 waterproof layers essential",
+      "60\u00b0F feels colder on the water with wind chill",
+      "Weather changes rapidly \u2014 dress in layers",
       "Summer cruise season is also the wettest period",
       "Mosquitoes can be intense near wetlands in Jul-Aug",
       "Trails can be muddy and slippery after rain"
@@ -48690,7 +49450,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "76-87°F year-round tropical",
+      "temp_range": "76-87\u00b0F year-round tropical",
       "humidity": "High year-round (78-80%)",
       "rain": "Wetter Dec-Feb; driest Jun-Aug",
       "wind": "Northwest monsoon (wet); southeast trades (dry, cooler)",
@@ -48729,10 +49489,10 @@
       "Feb"
     ],
     "catches_off_guard": [
-      "The Seychelles are expensive — budget accordingly",
+      "The Seychelles are expensive \u2014 budget accordingly",
       "Beach conditions vary by coast and monsoon direction",
       "Giant tortoises are year-round attractions",
-      "Some beaches have strong currents — check locally",
+      "Some beaches have strong currents \u2014 check locally",
       "Inter-island ferries can be rough in monsoon season"
     ],
     "packing_nudges": [
@@ -48744,7 +49504,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Nov – Apr (Indian Ocean cyclone season)",
+      "hurricane_season": "Nov \u2013 Apr (Indian Ocean cyclone season)",
       "peak_risk_months": [
         "Jan",
         "Feb",
@@ -48850,7 +49610,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "33-90°F wide seasonal range",
+      "temp_range": "33-90\u00b0F wide seasonal range",
       "humidity": "Muggy summers (78%+), moderate winters",
       "rain": "Plum rains Jun-Jul; typhoon risk Aug-Oct",
       "wind": "Cold winter winds off the sea",
@@ -48890,7 +49650,7 @@
       "Aug"
     ],
     "catches_off_guard": [
-      "Summer heat and humidity are genuinely oppressive (heat index 105°F+)",
+      "Summer heat and humidity are genuinely oppressive (heat index 105\u00b0F+)",
       "Plum rain season (mid-Jun to mid-Jul) brings nonstop drizzle",
       "Pollution can reduce visibility significantly",
       "Winter is colder than most expect for this latitude",
@@ -48905,7 +49665,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "May – Nov (Western Pacific typhoon season)",
+      "hurricane_season": "May \u2013 Nov (Western Pacific typhoon season)",
       "peak_risk_months": [
         "Aug",
         "Sep",
@@ -49011,9 +49771,9 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "53-101°F Sinai desert coast",
+      "temp_range": "53-101\u00b0F Sinai desert coast",
       "humidity": "Very low year-round",
-      "rain": "Zero — one of driest places on Earth",
+      "rain": "Zero \u2014 one of driest places on Earth",
       "wind": "Can be strong; affects snorkeling conditions",
       "daylight": "10.5-13.5 hours seasonal"
     },
@@ -49056,7 +49816,7 @@
     ],
     "catches_off_guard": [
       "Ras Mohammed National Park has world-class reefs",
-      "Summer is dangerously hot — even locals stay indoors midday",
+      "Summer is dangerously hot \u2014 even locals stay indoors midday",
       "Wind can shut down boat excursions to Tiran Island",
       "The Sinai desert interior is even hotter than the coast",
       "Naama Bay is walkable but other attractions require transport"
@@ -49170,7 +49930,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "74-91°F year-round tropical",
+      "temp_range": "74-91\u00b0F year-round tropical",
       "humidity": "High; peak in wet season",
       "rain": "Wet season May-Nov; dry Dec-Apr",
       "wind": "Southwest monsoon brings rain May-Oct",
@@ -49210,9 +49970,9 @@
     "catches_off_guard": [
       "Sihanoukville has changed dramatically with Chinese development",
       "Island beaches (Koh Rong) are the real attraction",
-      "Wet season seas can be rough — island trips may cancel",
-      "The town itself is a construction zone — manage expectations",
-      "Cambodian cuisine is underrated — seek out local restaurants"
+      "Wet season seas can be rough \u2014 island trips may cancel",
+      "The town itself is a construction zone \u2014 manage expectations",
+      "Cambodian cuisine is underrated \u2014 seek out local restaurants"
     ],
     "packing_nudges": [
       "Light breathable clothing",
@@ -49323,8 +50083,8 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "75-88°F year-round",
-      "humidity": "Very high (82-86%) — equatorial climate",
+      "temp_range": "75-88\u00b0F year-round",
+      "humidity": "Very high (82-86%) \u2014 equatorial climate",
       "rain": "Frequent afternoon thunderstorms year-round; wettest Nov-Jan",
       "wind": "Light; monsoon shifts Jun and Dec",
       "daylight": "~12 hours year-round (near equator)"
@@ -49364,7 +50124,7 @@
     "catches_off_guard": [
       "Afternoon thunderstorms appear suddenly even on sunny mornings",
       "Indoor attractions are essential backup plans",
-      "The heat index regularly exceeds 100°F",
+      "The heat index regularly exceeds 100\u00b0F",
       "Hawker centers and malls provide air-conditioned refuge",
       "Monsoon season (Nov-Jan) brings prolonged heavy rain"
     ],
@@ -49477,7 +50237,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "28-62°F — sheltered coastal rainforest",
+      "temp_range": "28-62\u00b0F \u2014 sheltered coastal rainforest",
       "humidity": "Very high year-round",
       "rain": "Frequent year-round; 86+ inches/year",
       "wind": "Moderate; ocean exposure from Pacific",
@@ -49521,7 +50281,7 @@
       "Mar"
     ],
     "catches_off_guard": [
-      "Sitka's Russian heritage makes it unique — see St. Michael's Cathedral",
+      "Sitka's Russian heritage makes it unique \u2014 see St. Michael's Cathedral",
       "The Alaska Raptor Center rehabilitates injured eagles and other raptors",
       "Sitka National Historical Park has totem poles in a rainforest setting",
       "Sea otter viewing is common in the harbor",
@@ -49636,7 +50396,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "17-65°F — drier than coastal Alaska",
+      "temp_range": "17-65\u00b0F \u2014 drier than coastal Alaska",
       "humidity": "Lower than other Alaska ports",
       "rain": "Drier than Juneau/Ketchikan; wettest Sep-Oct",
       "wind": "Moderate; funneled through valley",
@@ -49682,7 +50442,7 @@
     "catches_off_guard": [
       "The White Pass & Yukon Route Railway is a must-do excursion",
       "Skagway is a gold rush ghost town brought back to life",
-      "The historic district is walkable — 6 blocks of restored buildings",
+      "The historic district is walkable \u2014 6 blocks of restored buildings",
       "It's drier than other SE Alaska ports but still bring rain gear",
       "Chilkoot Trail (Gold Rush route) is nearby for serious hikers"
     ],
@@ -49795,7 +50555,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "40-84°F — perched on dramatic cliffs",
+      "temp_range": "40-84\u00b0F \u2014 perched on dramatic cliffs",
       "humidity": "Moderate (50-75%)",
       "rain": "Dry summers; wetter Oct-Feb",
       "wind": "Protected position; occasionally gusty",
@@ -49833,9 +50593,9 @@
       "Aug"
     ],
     "catches_off_guard": [
-      "Tender port — sea conditions can affect access",
+      "Tender port \u2014 sea conditions can affect access",
       "Amalfi Drive is spectacular but nauseating for some",
-      "Limoncello is everywhere — quality varies enormously",
+      "Limoncello is everywhere \u2014 quality varies enormously",
       "Pompeii is accessible but requires half a day",
       "Capri ferry from Marina Piccola is easy day trip"
     ],
@@ -49948,7 +50708,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "25-46°F — sub-Antarctic oceanic",
+      "temp_range": "25-46\u00b0F \u2014 sub-Antarctic oceanic",
       "humidity": "High year-round",
       "rain": "Frequent precipitation; snow at altitude",
       "wind": "Very strong; Southern Ocean exposure",
@@ -50102,7 +50862,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "67-86°F year-round tropical",
+      "temp_range": "67-86\u00b0F year-round tropical",
       "humidity": "High year-round; drier Jun-Oct",
       "rain": "Wet season Nov-Apr; dry season May-Oct",
       "wind": "Trade winds provide relief",
@@ -50147,7 +50907,7 @@
     ],
     "catches_off_guard": [
       "South Pacific cyclone season (Nov-Apr) can disrupt itineraries",
-      "Island time is real — schedules are flexible",
+      "Island time is real \u2014 schedules are flexible",
       "Each island group has distinct culture and customs",
       "Sunday observance is common across Polynesia",
       "Reef-safe sunscreen is increasingly required by law"
@@ -50161,7 +50921,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Nov – Apr (South Pacific cyclone season)",
+      "hurricane_season": "Nov \u2013 Apr (South Pacific cyclone season)",
       "peak_risk_months": [
         "Jan",
         "Feb",
@@ -50267,7 +51027,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "12-37°F — sub-Antarctic maritime",
+      "temp_range": "12-37\u00b0F \u2014 sub-Antarctic maritime",
       "humidity": "Very high",
       "rain": "Frequent snow, sleet, and rain",
       "wind": "Strong and persistent",
@@ -50416,8 +51176,8 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "46-72°F; cool maritime climate, mild year-round",
-      "humidity": "High (73-86%) — damp maritime climate",
+      "temp_range": "46-72\u00b0F; cool maritime climate, mild year-round",
+      "humidity": "High (73-86%) \u2014 damp maritime climate",
       "rain": "Frequent drizzle year-round; wettest Nov-Jan",
       "wind": "Coastal winds can be strong and chilly",
       "daylight": "8-16 hours; long summer evenings, short winter days"
@@ -50465,9 +51225,9 @@
       "Jan"
     ],
     "catches_off_guard": [
-      "Weather changes rapidly — rain can start anytime",
-      "70°F is considered 'warm' — British summer is mild by US standards",
-      "London is 90 minutes away by train — plan excursion time carefully",
+      "Weather changes rapidly \u2014 rain can start anytime",
+      "70\u00b0F is considered 'warm' \u2014 British summer is mild by US standards",
+      "London is 90 minutes away by train \u2014 plan excursion time carefully",
       "Port area is industrial with limited nearby attractions",
       "Winds make it feel colder than thermometer suggests",
       "Public transport strikes can disrupt London access"
@@ -50583,7 +51343,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "36-86°F — Dalmatian coast gem",
+      "temp_range": "36-86\u00b0F \u2014 Dalmatian coast gem",
       "humidity": "Moderate (45-68%)",
       "rain": "Dry Jun-Aug; wetter autumn/winter",
       "wind": "Bura (northeast cold) and Jugo (southeast warm)",
@@ -50623,16 +51383,16 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "Diocletian's Palace is a living city — people still live in it",
+      "Diocletian's Palace is a living city \u2014 people still live in it",
       "Game of Thrones scenes filmed here and nearby",
       "Marjan Hill park is perfect morning walk",
       "Riva waterfront promenade is social center",
-      "Ferry connections to Hvar, Brač, and Vis"
+      "Ferry connections to Hvar, Bra\u010d, and Vis"
     ],
     "packing_nudges": [
       "Comfortable walking shoes for palace",
       "Sunscreen",
-      "Swimsuit for Bačvice Beach",
+      "Swimsuit for Ba\u010dvice Beach",
       "Cash for konoba (traditional restaurants)"
     ],
     "hazards": {
@@ -50738,7 +51498,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "72-87°F year-round",
+      "temp_range": "72-87\u00b0F year-round",
       "humidity": "Moderate (68-76%)",
       "rain": "Brief showers; wetter Aug-Nov",
       "wind": "Brisk trades",
@@ -50777,8 +51537,8 @@
       "Sep"
     ],
     "catches_off_guard": [
-      "Extremely expensive — most upscale Caribbean island",
-      "Tiny harbor limits ship size — mostly luxury ships",
+      "Extremely expensive \u2014 most upscale Caribbean island",
+      "Tiny harbor limits ship size \u2014 mostly luxury ships",
       "French cuisine exceptional but pricey",
       "Shell Beach requires effort to reach",
       "Plane landing skims beach at St. Jean"
@@ -50791,7 +51551,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Sep",
         "Oct"
@@ -50897,7 +51657,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "72-89°F year-round",
+      "temp_range": "72-89\u00b0F year-round",
       "humidity": "Moderate (69-77%)",
       "rain": "Drier Jan-Apr; wetter Aug-Nov",
       "wind": "Steady trades",
@@ -50955,12 +51715,12 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Sep",
         "Oct"
       ],
-      "note": "USVI — no passport for US citizens"
+      "note": "USVI \u2014 no passport for US citizens"
     },
     "cruise_seasons": {
       "high": [
@@ -51061,7 +51821,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "57-78°F year-round mild oceanic",
+      "temp_range": "57-78\u00b0F year-round mild oceanic",
       "humidity": "Moderate year-round",
       "rain": "Light showers possible year-round; slightly wetter Mar-May",
       "wind": "Trade winds constant but moderate",
@@ -51102,11 +51862,11 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "Napoleon's exile island is the main draw — Longwood House is a must",
+      "Napoleon's exile island is the main draw \u2014 Longwood House is a must",
       "Jacob's Ladder (699 steps) is iconic but strenuous",
       "The island has an airport now but cruise is still the best way to visit",
       "Jonathan the tortoise is the world's oldest living land animal",
-      "Jamestown is squeezed into a narrow valley — quite unique"
+      "Jamestown is squeezed into a narrow valley \u2014 quite unique"
     ],
     "packing_nudges": [
       "Layers for variable temperatures",
@@ -51217,7 +51977,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "72-89°F year-round",
+      "temp_range": "72-89\u00b0F year-round",
       "humidity": "Moderate (68-76%)",
       "rain": "Drier Jan-May; wetter Aug-Nov",
       "wind": "Trades; calm bays",
@@ -51255,21 +52015,21 @@
       "Sep"
     ],
     "catches_off_guard": [
-      "Two-thirds national park — pristine",
+      "Two-thirds national park \u2014 pristine",
       "Trunk Bay often rated world's best beach",
-      "No cruise pier — tender or ferry from St. Thomas",
+      "No cruise pier \u2014 tender or ferry from St. Thomas",
       "Roads extremely steep and winding",
       "Rental vehicles are open-air safari style"
     ],
     "packing_nudges": [
-      "Reef-safe sunscreen — enforced in park",
+      "Reef-safe sunscreen \u2014 enforced in park",
       "Water shoes for reef",
       "Hiking shoes for Reef Bay Trail",
       "Reusable water bottle"
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Sep",
         "Oct"
@@ -51375,7 +52135,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "72-88°F year-round",
+      "temp_range": "72-88\u00b0F year-round",
       "humidity": "Moderate (69-77%)",
       "rain": "Drier Jan-Apr; wetter Jul-Nov",
       "wind": "Trades; breezy hilltops",
@@ -51415,7 +52175,7 @@
       "Brimstone Hill Fortress is UNESCO site",
       "Scenic Railway unique in Caribbean",
       "Port handles only 2 large ships",
-      "Black sand beaches — volcanic south end",
+      "Black sand beaches \u2014 volcanic south end",
       "Southeast Peninsula has best beaches"
     ],
     "packing_nudges": [
@@ -51426,7 +52186,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Sep",
         "Oct"
@@ -51532,7 +52292,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "72-88°F year-round",
+      "temp_range": "72-88\u00b0F year-round",
       "humidity": "Moderate to high (69-79%)",
       "rain": "Wetter than most Caribbean; rainforest",
       "wind": "Trades; calmer leeward coast",
@@ -51577,8 +52337,8 @@
     ],
     "catches_off_guard": [
       "Pitons hike is strenuous and steep",
-      "Long winding road to Soufrière from Castries",
-      "Wetter than flat islands — mountains catch rain",
+      "Long winding road to Soufri\u00e8re from Castries",
+      "Wetter than flat islands \u2014 mountains catch rain",
       "Sulphur Springs smells strong",
       "Chocolate tours surprisingly excellent"
     ],
@@ -51590,7 +52350,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Sep",
         "Oct"
@@ -51696,7 +52456,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "73-89°F year-round",
+      "temp_range": "73-89\u00b0F year-round",
       "humidity": "Moderate (71-77%)",
       "rain": "Brief showers; wetter Sep-Nov",
       "wind": "Trades",
@@ -51732,7 +52492,7 @@
       "Sep"
     ],
     "catches_off_guard": [
-      "Same island as Philipsburg — Dutch/French",
+      "Same island as Philipsburg \u2014 Dutch/French",
       "Maho Beach jet blast iconic",
       "5+ mega-ships at once",
       "French Marigot better dining",
@@ -51746,7 +52506,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Aug",
         "Sep",
@@ -51853,7 +52613,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "12-73°F — imperial city, extreme seasons",
+      "temp_range": "12-73\u00b0F \u2014 imperial city, extreme seasons",
       "humidity": "Moderate to high (60-87%)",
       "rain": "Year-round; wetter summer",
       "wind": "Neva River winds; cold in winter",
@@ -51895,11 +52655,11 @@
       "Feb"
     ],
     "catches_off_guard": [
-      "White Nights (late Jun) — sun barely sets, magical atmosphere",
-      "Hermitage Museum needs a full day minimum — overwhelming scale",
+      "White Nights (late Jun) \u2014 sun barely sets, magical atmosphere",
+      "Hermitage Museum needs a full day minimum \u2014 overwhelming scale",
       "Peterhof fountains (May-Oct) are Russia's Versailles",
-      "Visa requirements vary — check current regulations",
-      "Drawbridges raise at night — can trap you on wrong side"
+      "Visa requirements vary \u2014 check current regulations",
+      "Drawbridges raise at night \u2014 can trap you on wrong side"
     ],
     "packing_nudges": [
       "Layers for cool temperatures",
@@ -52010,7 +52770,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "72-90°F year-round",
+      "temp_range": "72-90\u00b0F year-round",
       "humidity": "Moderate (69-77%)",
       "rain": "Brief showers; wetter Aug-Nov",
       "wind": "Trades; Christmas Winds Dec-Feb",
@@ -52048,7 +52808,7 @@
     ],
     "catches_off_guard": [
       "Charlotte Amalie very crowded with multiple ships",
-      "Driving on the LEFT — watch as pedestrian",
+      "Driving on the LEFT \u2014 watch as pedestrian",
       "Mountain roads steep and narrow",
       "Christmas Winds make north beaches rough",
       "Duty-free not always cheap as advertised"
@@ -52061,7 +52821,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Aug",
         "Sep",
@@ -52168,7 +52928,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "27-66°F — oil capital, wet climate",
+      "temp_range": "27-66\u00b0F \u2014 oil capital, wet climate",
       "humidity": "High (69-83%)",
       "rain": "Wet year-round; one of Norway's wettest cities",
       "wind": "Exposed Atlantic coast",
@@ -52205,14 +52965,14 @@
       "Jan"
     ],
     "catches_off_guard": [
-      "Pulpit Rock (Preikestolen) hike is 4hr round trip — famous cliff",
+      "Pulpit Rock (Preikestolen) hike is 4hr round trip \u2014 famous cliff",
       "Lysefjord cruise is spectacular alternative to hiking",
       "Old Stavanger (Gamle Stavanger) has 173 white wooden houses",
       "Norwegian Petroleum Museum tells oil story",
-      "Rain is almost guaranteed — 200+ days/year"
+      "Rain is almost guaranteed \u2014 200+ days/year"
     ],
     "packing_nudges": [
-      "Waterproof everything — jacket, pants, shoes",
+      "Waterproof everything \u2014 jacket, pants, shoes",
       "Hiking boots for Pulpit Rock",
       "Layers for mountain weather",
       "Cash for street food"
@@ -52320,7 +53080,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "21-72°F — archipelago capital",
+      "temp_range": "21-72\u00b0F \u2014 archipelago capital",
       "humidity": "Moderate to high (58-87%)",
       "rain": "Year-round; wetter late summer",
       "wind": "Moderate; sheltered by archipelago",
@@ -52361,7 +53121,7 @@
       "Vasa Museum (intact 17th-century warship) is a must",
       "Old Town (Gamla Stan) is compact and photogenic",
       "ABBA Museum is surprisingly entertaining",
-      "Archipelago has 30,000 islands — ferries connect many",
+      "Archipelago has 30,000 islands \u2014 ferries connect many",
       "Fika (coffee break) culture is social ritual"
     ],
     "packing_nudges": [
@@ -52473,10 +53233,10 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "29-56°F — Patagonian strait",
+      "temp_range": "29-56\u00b0F \u2014 Patagonian strait",
       "humidity": "Moderate to high",
       "rain": "Frequent; less than open ocean",
-      "wind": "Very strong — funneling effect through strait",
+      "wind": "Very strong \u2014 funneling effect through strait",
       "daylight": "7.5-17 hours (seasonal)"
     },
     "best_months_for": {
@@ -52505,10 +53265,10 @@
       "Aug"
     ],
     "catches_off_guard": [
-      "The Strait connects the Atlantic and Pacific — historic navigation route",
+      "The Strait connects the Atlantic and Pacific \u2014 historic navigation route",
       "Magellan was the first European to transit in 1520",
       "Dolphins and penguins are commonly spotted",
-      "The strait is calmer than rounding Cape Horn — ships appreciate this",
+      "The strait is calmer than rounding Cape Horn \u2014 ships appreciate this",
       "Glaciers are visible from the ship in places"
     ],
     "packing_nudges": [
@@ -52620,7 +53380,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "67-86°F year-round tropical",
+      "temp_range": "67-86\u00b0F year-round tropical",
       "humidity": "High year-round; very wet",
       "rain": "Wet year-round; wetter Nov-Apr",
       "wind": "Trade winds; sheltered harbor",
@@ -52660,10 +53420,10 @@
       "The municipal market is vibrant and authentic",
       "Fiji Museum has excellent Pacific cultural exhibits",
       "Colo-i-Suva rainforest park is accessible but muddy in wet season",
-      "Suva is the commercial capital — less resort-like than western Fiji"
+      "Suva is the commercial capital \u2014 less resort-like than western Fiji"
     ],
     "packing_nudges": [
-      "Rain gear essential — Suva is very wet",
+      "Rain gear essential \u2014 Suva is very wet",
       "Light breathable clothing",
       "Comfortable walking shoes",
       "Modest clothing for cultural sites",
@@ -52671,7 +53431,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Nov – Apr (South Pacific cyclone season)",
+      "hurricane_season": "Nov \u2013 Apr (South Pacific cyclone season)",
       "peak_risk_months": [
         "Jan",
         "Feb",
@@ -52777,7 +53537,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "44-79°F — mild oceanic (Southern Hemisphere)",
+      "temp_range": "44-79\u00b0F \u2014 mild oceanic (Southern Hemisphere)",
       "humidity": "Moderate; drier winter",
       "rain": "Distributed year-round; slightly wetter in autumn",
       "wind": "Sea breezes afternoon; southerly busters possible",
@@ -52821,15 +53581,15 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "Sydney's UV index is extreme in summer — sunburn in 15 minutes",
-      "Bondi Beach can have dangerous rip currents — swim between flags",
-      "Southerly busters bring sudden temperature drops of 20°F+",
+      "Sydney's UV index is extreme in summer \u2014 sunburn in 15 minutes",
+      "Bondi Beach can have dangerous rip currents \u2014 swim between flags",
+      "Southerly busters bring sudden temperature drops of 20\u00b0F+",
       "Harbour Bridge and Opera House are exposed to wind and sun",
       "Winter is mild but evenings can be surprisingly cool"
     ],
     "packing_nudges": [
       "Sunscreen SPF 50+ (Australian sun is intense)",
-      "Layers — temperature varies throughout the day",
+      "Layers \u2014 temperature varies throughout the day",
       "Comfortable walking shoes",
       "Light rain jacket",
       "Swimwear for beach visits"
@@ -52936,10 +53696,10 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "13-73°F — Cape Breton Island maritime",
+      "temp_range": "13-73\u00b0F \u2014 Cape Breton Island maritime",
       "humidity": "Moderate to high",
       "rain": "Distributed; fog and drizzle common",
-      "wind": "Can be very strong — exposed island",
+      "wind": "Can be very strong \u2014 exposed island",
       "daylight": "8.5-15.5 hours seasonal"
     },
     "best_months_for": {
@@ -52976,13 +53736,13 @@
     ],
     "catches_off_guard": [
       "The Cabot Trail is one of the world's greatest scenic drives",
-      "Cape Breton has strong Celtic/Scottish culture — music and dance",
+      "Cape Breton has strong Celtic/Scottish culture \u2014 music and dance",
       "Fall foliage on the Cabot Trail (Oct) is spectacular",
       "Alexander Graham Bell Museum is in nearby Baddeck",
       "Louisbourg Fortress (18th-century French) is a 30-min drive"
     ],
     "packing_nudges": [
-      "Warm layers — Cape Breton is cool even in summer",
+      "Warm layers \u2014 Cape Breton is cool even in summer",
       "Waterproof jacket",
       "Comfortable hiking shoes for Cabot Trail stops",
       "Warm hat and gloves for fall",
@@ -53090,7 +53850,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "55-92°F subtropical range",
+      "temp_range": "55-92\u00b0F subtropical range",
       "humidity": "High year-round (72-79%)",
       "rain": "Rainy season Feb-Jun; typhoons Jul-Oct",
       "wind": "Light monsoon winds",
@@ -53132,7 +53892,7 @@
       "Aug"
     ],
     "catches_off_guard": [
-      "Taipei gets over 200 rainy days per year — always carry an umbrella",
+      "Taipei gets over 200 rainy days per year \u2014 always carry an umbrella",
       "Summer heat plus humidity is genuinely oppressive",
       "Typhoons can strand cruise ships Jul-Oct",
       "Night markets are year-round but more comfortable in cooler months",
@@ -53147,7 +53907,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "May – Nov (Western Pacific typhoon season)",
+      "hurricane_season": "May \u2013 Nov (Western Pacific typhoon season)",
       "peak_risk_months": [
         "Aug",
         "Sep",
@@ -53253,7 +54013,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "14-71°F — medieval gem on the Baltic",
+      "temp_range": "14-71\u00b0F \u2014 medieval gem on the Baltic",
       "humidity": "Moderate to high (63-88%)",
       "rain": "Year-round; slightly drier spring",
       "wind": "Baltic winds",
@@ -53408,8 +54168,8 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "71-91°F; hot humid summers with daily storms, mild winters",
-      "humidity": "Moderate to High (65-76%) — oppressive in summer",
+      "temp_range": "71-91\u00b0F; hot humid summers with daily storms, mild winters",
+      "humidity": "Moderate to High (65-76%) \u2014 oppressive in summer",
       "rain": "Daily afternoon thunderstorms Jun-Sep (lightning capital of US)",
       "wind": "Light Gulf breezes; stronger during storms",
       "daylight": "10-14 hours; consistent year-round"
@@ -53452,11 +54212,11 @@
       "Sep"
     ],
     "catches_off_guard": [
-      "Tampa is the lightning capital of the US — daily summer storms are dangerous",
+      "Tampa is the lightning capital of the US \u2014 daily summer storms are dangerous",
       "Afternoon thunderstorms Jun-Sep arrive like clockwork around 3-4pm",
       "Hurricane season means possible cruise cancellations/diversions",
-      "Port is industrial — attractions require taxi/shuttle",
-      "Summer humidity makes 90°F feel dangerously hot (heat index 105°F+)",
+      "Port is industrial \u2014 attractions require taxi/shuttle",
+      "Summer humidity makes 90\u00b0F feel dangerously hot (heat index 105\u00b0F+)",
       "Busch Gardens is 45+ minutes from port"
     ],
     "packing_nudges": [
@@ -53469,7 +54229,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic/Gulf)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic/Gulf)",
       "peak_risk_months": [
         "Aug",
         "Sep",
@@ -53576,10 +54336,10 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "47-83°F — Strait of Gibraltar Mediterranean",
+      "temp_range": "47-83\u00b0F \u2014 Strait of Gibraltar Mediterranean",
       "humidity": "Moderate",
       "rain": "Wet winters; dry summers",
-      "wind": "Can be strong — Strait of Gibraltar funneling",
+      "wind": "Can be strong \u2014 Strait of Gibraltar funneling",
       "daylight": "9.5-14.5 hours seasonal"
     },
     "best_months_for": {
@@ -53617,7 +54377,7 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "Tangier's medina is less touristy than Marrakech — more authentic",
+      "Tangier's medina is less touristy than Marrakech \u2014 more authentic",
       "The Kasbah Museum has excellent Moroccan art",
       "Cap Spartel (where Atlantic meets Mediterranean) is scenic",
       "Literary legends (Bowles, Burroughs, Kerouac) lived here",
@@ -53732,7 +54492,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "43-86°F — hillside town with views",
+      "temp_range": "43-86\u00b0F \u2014 hillside town with views",
       "humidity": "Moderate (43-71%)",
       "rain": "Dry summers; moderate winters",
       "wind": "Exposed position; breezy",
@@ -53771,15 +54531,15 @@
     ],
     "catches_off_guard": [
       "Ancient Greek Theatre with Etna backdrop is jaw-dropping",
-      "Perched on cliff — steep walking everywhere",
+      "Perched on cliff \u2014 steep walking everywhere",
       "Isola Bella beach below requires cable car or steep walk",
       "August is extremely crowded and hot",
       "Granita (frozen dessert) is better than gelato here"
     ],
     "packing_nudges": [
-      "Comfortable shoes — steep terrain",
+      "Comfortable shoes \u2014 steep terrain",
       "Sunscreen",
-      "Camera — views are extraordinary",
+      "Camera \u2014 views are extraordinary",
       "Cash for granita stands"
     ],
     "hazards": {
@@ -53885,7 +54645,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "39-76°F mild maritime",
+      "temp_range": "39-76\u00b0F mild maritime",
       "humidity": "Moderate to high",
       "rain": "Distributed year-round; slightly drier summer",
       "wind": "Moderate coastal breezes",
@@ -53927,9 +54687,9 @@
     "avoid_months": [],
     "catches_off_guard": [
       "Mount Maunganui (The Mount) is a must-climb for panoramic views",
-      "Hobbiton Movie Set is 45 min drive — book ahead in cruise season",
+      "Hobbiton Movie Set is 45 min drive \u2014 book ahead in cruise season",
       "White Island (Whakaari) volcano tours are weather-dependent",
-      "The Bay of Plenty lives up to its name — abundant produce",
+      "The Bay of Plenty lives up to its name \u2014 abundant produce",
       "Rotorua (geothermal) is a popular day excursion (1 hour)"
     ],
     "packing_nudges": [
@@ -54041,7 +54801,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "65-85°F typical cruise destination range",
+      "temp_range": "65-85\u00b0F typical cruise destination range",
       "humidity": "Moderate to high",
       "rain": "Variable by location",
       "wind": "Light to moderate",
@@ -54063,7 +54823,7 @@
       "Tender ports require small boat transfers from ship to shore",
       "Transfers can be cancelled in rough seas or high winds",
       "Mobility-limited passengers should check tender accessibility",
-      "Arrive at the tender meeting point early — lines form quickly",
+      "Arrive at the tender meeting point early \u2014 lines form quickly",
       "Some tender ports have limited facilities ashore"
     ],
     "packing_nudges": [
@@ -54175,7 +54935,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "56-84°F — diverse microclimates",
+      "temp_range": "56-84\u00b0F \u2014 diverse microclimates",
       "humidity": "Moderate (57-66%)",
       "rain": "Very little in south; wetter north",
       "wind": "Trade winds; calima (Saharan dust) possible",
@@ -54219,8 +54979,8 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "Mount Teide is Spain's highest peak — cable car to near summit",
-      "Calima brings Saharan dust and heat — visibility drops",
+      "Mount Teide is Spain's highest peak \u2014 cable car to near summit",
+      "Calima brings Saharan dust and heat \u2014 visibility drops",
       "North Tenerife is green and lush; south is arid resort area",
       "Loro Parque is popular but controversial",
       "Whale watching off west coast year-round"
@@ -54334,7 +55094,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "16-90°F extreme continental range",
+      "temp_range": "16-90\u00b0F extreme continental range",
       "humidity": "Low winter, muggy summer",
       "rain": "Concentrated Jul-Aug monsoon rains; dry winters",
       "wind": "Cold dry winter winds; dusty springs",
@@ -54369,11 +55129,11 @@
       "Feb"
     ],
     "catches_off_guard": [
-      "This is Beijing's cruise port — expect a long transfer",
-      "Winter is bitterly cold with wind chill well below 0°F",
+      "This is Beijing's cruise port \u2014 expect a long transfer",
+      "Winter is bitterly cold with wind chill well below 0\u00b0F",
       "Summer heat and humidity are intense",
       "Spring dust storms can disrupt plans",
-      "Smog can be severe — check air quality index"
+      "Smog can be severe \u2014 check air quality index"
     ],
     "packing_nudges": [
       "Heavy winter coat, hat, gloves for Nov-Mar",
@@ -54484,7 +55244,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "72-88°F year-round",
+      "temp_range": "72-88\u00b0F year-round",
       "humidity": "Moderate to high (71-80%)",
       "rain": "Dry Jan-May; wet Jun-Nov",
       "wind": "Trades; breezy east coast",
@@ -54543,7 +55303,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Sep",
         "Oct"
@@ -54649,7 +55409,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "36-86°F four distinct seasons",
+      "temp_range": "36-86\u00b0F four distinct seasons",
       "humidity": "Muggy Jun-Sep; pleasant spring/fall",
       "rain": "Rainy season (tsuyu) mid-Jun to mid-Jul; typhoons Aug-Oct",
       "wind": "Moderate; stronger winter winds",
@@ -54686,7 +55446,7 @@
       "Aug"
     ],
     "catches_off_guard": [
-      "Cherry blossom timing varies year to year — don't count on exact dates",
+      "Cherry blossom timing varies year to year \u2014 don't count on exact dates",
       "Tsuyu (rainy season) in June brings weeks of gray drizzle",
       "Summer heat plus humidity creates miserable outdoor conditions",
       "Typhoons can disrupt port calls Sep-Oct",
@@ -54697,11 +55457,11 @@
       "Light rain jacket year-round",
       "Breathable clothing for summer",
       "Light jacket for winter",
-      "Comfortable walking shoes — you'll walk a lot"
+      "Comfortable walking shoes \u2014 you'll walk a lot"
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "May – Nov (Western Pacific typhoon season)",
+      "hurricane_season": "May \u2013 Nov (Western Pacific typhoon season)",
       "peak_risk_months": [
         "Aug",
         "Sep",
@@ -54807,7 +55567,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "62-86°F year-round warm",
+      "temp_range": "62-86\u00b0F year-round warm",
       "humidity": "High; lower in drier winter",
       "rain": "Wet season Nov-Apr; drier May-Oct",
       "wind": "Trade winds; cyclone risk",
@@ -54852,9 +55612,9 @@
     "catches_off_guard": [
       "Tonga is the only Pacific kingdom never colonized by Europeans",
       "Humpback whale watching (Jul-Oct) is world-class",
-      "Sunday is strictly observed — nothing is open",
+      "Sunday is strictly observed \u2014 nothing is open",
       "The Ha'amonga trilithon is Tonga's Stonehenge",
-      "Tonga was impacted by the 2022 volcanic eruption — resilience is evident"
+      "Tonga was impacted by the 2022 volcanic eruption \u2014 resilience is evident"
     ],
     "packing_nudges": [
       "Light breathable clothing",
@@ -54865,7 +55625,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Nov – Apr (South Pacific cyclone season)",
+      "hurricane_season": "Nov \u2013 Apr (South Pacific cyclone season)",
       "peak_risk_months": [
         "Jan",
         "Feb",
@@ -54971,9 +55731,9 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "33-56°F — North Atlantic oceanic",
+      "temp_range": "33-56\u00b0F \u2014 North Atlantic oceanic",
       "humidity": "Very high year-round",
-      "rain": "Very frequent — over 300 overcast days/year",
+      "rain": "Very frequent \u2014 over 300 overcast days/year",
       "wind": "Extremely windy",
       "daylight": "5-20 hours (dramatic seasonal variation)"
     },
@@ -55006,7 +55766,7 @@
     "avoid_months": [],
     "catches_off_guard": [
       "The Faroe Islands are among the world's most dramatic landscapes",
-      "Múlafossur waterfall (Vágar island) plunges directly into the ocean",
+      "M\u00falafossur waterfall (V\u00e1gar island) plunges directly into the ocean",
       "Puffins nest in the cliffs May-August",
       "The islands have more sheep than people (50,000 sheep, 50,000 people)",
       "Fog can obscure views but creates an ethereal atmosphere"
@@ -55015,7 +55775,7 @@
       "Full waterproof gear essential",
       "Warm layers under waterproofs",
       "Sturdy waterproof hiking boots",
-      "Warm hat and gloves — wind is constant",
+      "Warm hat and gloves \u2014 wind is constant",
       "Extra dry socks"
     ],
     "hazards": {
@@ -55121,7 +55881,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "72-89°F year-round",
+      "temp_range": "72-89\u00b0F year-round",
       "humidity": "Moderate (68-76%)",
       "rain": "Brief showers; wetter Aug-Nov",
       "wind": "Trades; Christmas Winds Dec-Feb",
@@ -55159,7 +55919,7 @@
       "Sep"
     ],
     "catches_off_guard": [
-      "Road Town pier small — limited facilities",
+      "Road Town pier small \u2014 limited facilities",
       "The Baths (Virgin Gorda) require ferry",
       "Mountain roads steep and narrow",
       "BVI uses US dollar despite being British",
@@ -55173,7 +55933,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Aug",
         "Sep",
@@ -55280,7 +56040,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "22-61°F glacial fjord",
+      "temp_range": "22-61\u00b0F glacial fjord",
       "humidity": "High",
       "rain": "Frequent",
       "wind": "Cold glacial gusts",
@@ -55320,10 +56080,10 @@
     ],
     "catches_off_guard": [
       "Twin Sawyer Glaciers are the main attraction",
-      "Icebergs can block passage — ships sometimes divert to Endicott Arm",
+      "Icebergs can block passage \u2014 ships sometimes divert to Endicott Arm",
       "The narrow fjord creates dramatic scenery with waterfalls",
       "Black bears and mountain goats spotted on shore",
-      "This is scenic cruising — you stay on the ship"
+      "This is scenic cruising \u2014 you stay on the ship"
     ],
     "packing_nudges": [
       "Warm waterproof layers",
@@ -55434,10 +56194,10 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "33-83°F — Adriatic meets Central Europe",
+      "temp_range": "33-83\u00b0F \u2014 Adriatic meets Central Europe",
       "humidity": "Moderate (55-68%)",
       "rain": "Year-round; slightly drier summer",
-      "wind": "Bora (northeast) can be extreme — 100+ mph",
+      "wind": "Bora (northeast) can be extreme \u2014 100+ mph",
       "daylight": "9-15.5 hours"
     },
     "best_months_for": {
@@ -55469,13 +56229,13 @@
     ],
     "catches_off_guard": [
       "Bora wind can literally knock people off their feet",
-      "Coffee culture rivals Vienna — order capo not cappuccino",
+      "Coffee culture rivals Vienna \u2014 order capo not cappuccino",
       "Habsburg architecture gives Central European feel",
       "Miramare Castle on the seafront is stunning",
       "Joyce and Svevo literary connections are strong"
     ],
     "packing_nudges": [
-      "Windproof jacket — Bora is real",
+      "Windproof jacket \u2014 Bora is real",
       "Comfortable walking shoes",
       "Warm layers for winter",
       "Coffee vocabulary (different from rest of Italy)"
@@ -55583,7 +56343,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "69-89°F year-round",
+      "temp_range": "69-89\u00b0F year-round",
       "humidity": "Moderate to high (69-79%)",
       "rain": "Dry Jan-May; very wet Jun-Nov",
       "wind": "Moderate trades",
@@ -55638,7 +56398,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Sep",
         "Oct"
@@ -55744,10 +56504,10 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "44-67°F cool oceanic year-round",
-      "humidity": "High year-round — maritime climate",
-      "rain": "Frequent — rain possible any day, any month",
-      "wind": "Very strong and persistent — one of windiest places on Earth",
+      "temp_range": "44-67\u00b0F cool oceanic year-round",
+      "humidity": "High year-round \u2014 maritime climate",
+      "rain": "Frequent \u2014 rain possible any day, any month",
+      "wind": "Very strong and persistent \u2014 one of windiest places on Earth",
       "daylight": "9-15 hours (Southern Hemisphere)"
     },
     "best_months_for": {
@@ -55776,10 +56536,10 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "Most remote inhabited island on Earth — 250 residents",
-      "Landing is entirely weather-dependent — ships often cannot dock",
+      "Most remote inhabited island on Earth \u2014 250 residents",
+      "Landing is entirely weather-dependent \u2014 ships often cannot dock",
       "The settlement of Edinburgh of the Seven Seas is the only town",
-      "There is no airport and no hotel — day visits only",
+      "There is no airport and no hotel \u2014 day visits only",
       "Rockhopper penguins and albatross nest on the cliffs"
     ],
     "packing_nudges": [
@@ -55891,11 +56651,11 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "17-61°F — Arctic city, dramatic seasons",
+      "temp_range": "17-61\u00b0F \u2014 Arctic city, dramatic seasons",
       "humidity": "High (66-80%)",
       "rain": "Year-round; wetter late summer and autumn",
       "wind": "Arctic winds; exposed coast",
-      "daylight": "0-24 hours — polar night Dec, midnight sun Jun"
+      "daylight": "0-24 hours \u2014 polar night Dec, midnight sun Jun"
     },
     "best_months_for": {
       "northern_lights": [
@@ -55930,7 +56690,7 @@
       "Jan"
     ],
     "catches_off_guard": [
-      "Polar night (Nov-Jan) means NO sunrise — magical aurora viewing",
+      "Polar night (Nov-Jan) means NO sunrise \u2014 magical aurora viewing",
       "Midnight Sun (May-Jul) means 24-hour daylight",
       "Arctic Cathedral is iconic modern architecture",
       "Gateway to Arctic wilderness",
@@ -56045,7 +56805,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "43-91°F — North African Mediterranean",
+      "temp_range": "43-91\u00b0F \u2014 North African Mediterranean",
       "humidity": "Lower than European Med; drier",
       "rain": "Winter rain; very dry summers",
       "wind": "Sirocco (hot desert wind) possible spring/fall",
@@ -56092,10 +56852,10 @@
     ],
     "catches_off_guard": [
       "The ruins of Carthage are a UNESCO World Heritage site",
-      "Sidi Bou Saïd (blue and white village) is one of the Med's most photogenic spots",
+      "Sidi Bou Sa\u00efd (blue and white village) is one of the Med's most photogenic spots",
       "The Bardo Museum has the world's best Roman mosaic collection",
-      "The medina of Tunis is UNESCO-listed — oldest in North Africa",
-      "Summer heat can be genuinely oppressive — 100°F+ in July-Aug"
+      "The medina of Tunis is UNESCO-listed \u2014 oldest in North Africa",
+      "Summer heat can be genuinely oppressive \u2014 100\u00b0F+ in July-Aug"
     ],
     "packing_nudges": [
       "Light layers for spring/fall",
@@ -56206,10 +56966,10 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "27-57°F — world's southernmost city",
+      "temp_range": "27-57\u00b0F \u2014 world's southernmost city",
       "humidity": "Moderate to high",
       "rain": "Distributed year-round; snow in winter",
-      "wind": "Very strong and persistent — Patagonian winds",
+      "wind": "Very strong and persistent \u2014 Patagonian winds",
       "daylight": "7-17+ hours (extreme seasonal variation)"
     },
     "best_months_for": {
@@ -56249,10 +57009,10 @@
       "Aug"
     ],
     "catches_off_guard": [
-      "This is the gateway to Antarctica — most expedition cruises depart here",
+      "This is the gateway to Antarctica \u2014 most expedition cruises depart here",
       "Tierra del Fuego National Park is spectacular but weather-dependent",
-      "Summer daylight lasts 17+ hours — bring an eye mask",
-      "Wind is relentless year-round — secure everything",
+      "Summer daylight lasts 17+ hours \u2014 bring an eye mask",
+      "Wind is relentless year-round \u2014 secure everything",
       "The End of the World train is touristy but scenic"
     ],
     "packing_nudges": [
@@ -56283,6 +57043,157 @@
         "Jul",
         "Aug",
         "Sep"
+      ]
+    }
+  },
+  "valdez": {
+    "tier": 1,
+    "timezone": "America/Anchorage",
+    "_source": "High/low/rain_days: Valdez NOAA 1991-2020 (Wikipedia climate table, session 2026-09-03). Humidity: Whittier entry in this file (Prince William Sound nearest existing station).",
+    "monthly_averages": {
+      "jan": {
+        "high_f": 29,
+        "low_f": 19,
+        "rain_days": 16,
+        "humidity": 73
+      },
+      "feb": {
+        "high_f": 32,
+        "low_f": 21,
+        "rain_days": 15,
+        "humidity": 71
+      },
+      "mar": {
+        "high_f": 37,
+        "low_f": 23,
+        "rain_days": 14,
+        "humidity": 69
+      },
+      "apr": {
+        "high_f": 46,
+        "low_f": 32,
+        "rain_days": 14,
+        "humidity": 67
+      },
+      "may": {
+        "high_f": 56,
+        "low_f": 40,
+        "rain_days": 15,
+        "humidity": 68
+      },
+      "jun": {
+        "high_f": 62,
+        "low_f": 46,
+        "rain_days": 14,
+        "humidity": 72
+      },
+      "jul": {
+        "high_f": 64,
+        "low_f": 49,
+        "rain_days": 18,
+        "humidity": 77
+      },
+      "aug": {
+        "high_f": 62,
+        "low_f": 47,
+        "rain_days": 18,
+        "humidity": 79
+      },
+      "sep": {
+        "high_f": 55,
+        "low_f": 42,
+        "rain_days": 21,
+        "humidity": 80
+      },
+      "oct": {
+        "high_f": 45,
+        "low_f": 34,
+        "rain_days": 19,
+        "humidity": 79
+      },
+      "nov": {
+        "high_f": 34,
+        "low_f": 25,
+        "rain_days": 16,
+        "humidity": 76
+      },
+      "dec": {
+        "high_f": 31,
+        "low_f": 22,
+        "rain_days": 17,
+        "humidity": 75
+      }
+    },
+    "at_a_glance": {
+      "temp_range": "19-64\u00b0F \u2014 snow capital of the cruise belt",
+      "humidity": "High; PWS marine air",
+      "rain": "~67-82 in/year; heavy winter snow",
+      "wind": "Thompson Pass is a different climate inland",
+      "daylight": "5.5-19.5 hours (seasonal)"
+    },
+    "best_months_for": {
+      "columbia_glacier": [
+        "May",
+        "Jun",
+        "Jul",
+        "Aug"
+      ],
+      "city_walking": [
+        "Jun",
+        "Jul",
+        "Aug"
+      ],
+      "wildlife": [
+        "Jun",
+        "Jul",
+        "Aug"
+      ],
+      "low_crowds": [
+        "May",
+        "Sep"
+      ]
+    },
+    "avoid_months": [
+      "Nov",
+      "Dec",
+      "Jan",
+      "Feb",
+      "Mar"
+    ],
+    "catches_off_guard": [
+      "Winter snow totals here are extreme; summer is cool and wet, not snowy",
+      "The pipeline terminal is industrial; town is a few miles away",
+      "Columbia Glacier is a boat day, not a dock stroll",
+      "This is Prince William Sound, not the Inside Passage",
+      "Shoulder-season calls can meet leftover snow on the passes"
+    ],
+    "packing_nudges": [
+      "Warm layer for glacier water",
+      "Waterproof jacket",
+      "Gloves for the boat deck",
+      "Binoculars"
+    ],
+    "hazards": {
+      "hurricane_zone": false
+    },
+    "cruise_seasons": {
+      "high": [
+        "Jun",
+        "Jul",
+        "Aug"
+      ],
+      "transitional": [
+        "May",
+        "Sep"
+      ],
+      "low": [
+        "Oct",
+        "Nov",
+        "Dec",
+        "Jan",
+        "Feb",
+        "Mar",
+        "Apr"
       ]
     }
   },
@@ -56364,9 +57275,9 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "42-86°F — warm Mediterranean",
+      "temp_range": "42-86\u00b0F \u2014 warm Mediterranean",
       "humidity": "Moderate (53-67%)",
-      "rain": "Dry summers; autumn gota fría floods possible",
+      "rain": "Dry summers; autumn gota fr\u00eda floods possible",
       "wind": "Sea breezes moderate heat",
       "daylight": "9.5-15 hours"
     },
@@ -56407,8 +57318,8 @@
     "catches_off_guard": [
       "City of Arts and Sciences is architecturally stunning",
       "Las Fallas festival (Mar) fills city with fire and noise",
-      "Paella was invented here — order it only at lunch",
-      "Autumn gota fría can bring sudden flash floods",
+      "Paella was invented here \u2014 order it only at lunch",
+      "Autumn gota fr\u00eda can bring sudden flash floods",
       "Turia Gardens (dry riverbed park) is perfect for cycling"
     ],
     "packing_nudges": [
@@ -56419,7 +57330,7 @@
     ],
     "hazards": {
       "hurricane_zone": false,
-      "note": "Occasional violent autumn storms (gota fría)"
+      "note": "Occasional violent autumn storms (gota fr\u00eda)"
     },
     "cruise_seasons": {
       "high": [
@@ -56520,7 +57431,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "47-87°F — fortress city in the sun",
+      "temp_range": "47-87\u00b0F \u2014 fortress city in the sun",
       "humidity": "Moderate (52-75%)",
       "rain": "Dry May-Aug; wet Oct-Feb",
       "wind": "Gregale (northeast) in winter; generally breezy",
@@ -56574,7 +57485,7 @@
       "Maltese cuisine fuses Italian, Arabic, and British influences"
     ],
     "packing_nudges": [
-      "Comfortable walking shoes — limestone streets can be slippery",
+      "Comfortable walking shoes \u2014 limestone streets can be slippery",
       "Sunscreen for summer",
       "Light layers for air-conditioned churches",
       "Cash for local pastizzi shops"
@@ -56682,7 +57593,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "43-72°F — cool Mediterranean (Southern Hemisphere)",
+      "temp_range": "43-72\u00b0F \u2014 cool Mediterranean (Southern Hemisphere)",
       "humidity": "Moderate; drier summer",
       "rain": "Winter rain (May-Aug); bone-dry summer",
       "wind": "Coastal breezes; can be strong",
@@ -56725,9 +57636,9 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "Valparaíso's cerros (hills) are connected by historic funiculars",
+      "Valpara\u00edso's cerros (hills) are connected by historic funiculars",
       "UNESCO-listed port city with incredible street art on every wall",
-      "The city is very hilly — comfortable shoes are essential",
+      "The city is very hilly \u2014 comfortable shoes are essential",
       "Pablo Neruda's La Sebastiana house is a must-visit",
       "Santiago is 1.5 hours inland for a full day excursion"
     ],
@@ -56840,7 +57751,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "33-71°F — mild Pacific maritime",
+      "temp_range": "33-71\u00b0F \u2014 mild Pacific maritime",
       "humidity": "Moderate; wet winters, dry summers",
       "rain": "Very wet Oct-Mar; dry Jul-Aug",
       "wind": "Light to moderate",
@@ -56887,7 +57798,7 @@
       "Summer is spectacularly sunny; winter is rain for months"
     ],
     "packing_nudges": [
-      "Layers — even summer evenings are cool",
+      "Layers \u2014 even summer evenings are cool",
       "Rain jacket essential Oct-Mar",
       "Comfortable walking shoes",
       "Sunscreen for summer",
@@ -56995,7 +57906,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "66-87°F year-round tropical",
+      "temp_range": "66-87\u00b0F year-round tropical",
       "humidity": "High; drier Jun-Oct",
       "rain": "Wet season Nov-Apr; drier May-Oct",
       "wind": "Trade winds; cyclone risk",
@@ -57040,10 +57951,10 @@
     ],
     "catches_off_guard": [
       "Mt. Yasur on Tanna Island is one of the most accessible active volcanoes",
-      "Ni-Vanuatu culture is incredibly diverse — 100+ languages",
+      "Ni-Vanuatu culture is incredibly diverse \u2014 100+ languages",
       "Kava bars are a unique cultural experience",
       "Underwater post office at Hideaway Island is a novelty",
-      "Vanuatu was devastated by Cyclone Pam (2015) — rebuilt with resilience"
+      "Vanuatu was devastated by Cyclone Pam (2015) \u2014 rebuilt with resilience"
     ],
     "packing_nudges": [
       "Light breathable clothing",
@@ -57054,7 +57965,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Nov – Apr (South Pacific cyclone season)",
+      "hurricane_season": "Nov \u2013 Apr (South Pacific cyclone season)",
       "peak_risk_months": [
         "Jan",
         "Feb",
@@ -57160,8 +58071,8 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "45-84°F; hot humid summers, cold damp winters",
-      "humidity": "High (67-80%) — lagoon location creates persistent dampness",
+      "temp_range": "45-84\u00b0F; hot humid summers, cold damp winters",
+      "humidity": "High (67-80%) \u2014 lagoon location creates persistent dampness",
       "rain": "Consistent year-round; Acqua Alta flooding Oct-Dec",
       "wind": "Generally calm; humid and still in summer",
       "daylight": "9-15 hours; early sunsets in winter amplify dampness"
@@ -57204,11 +58115,11 @@
       "Nov"
     ],
     "catches_off_guard": [
-      "Acqua Alta (flooding) can occur Oct-Jan — St. Mark's Square goes underwater",
-      "Cruise ships now dock far from city — shuttle or water taxi required (€€€)",
+      "Acqua Alta (flooding) can occur Oct-Jan \u2014 St. Mark's Square goes underwater",
+      "Cruise ships now dock far from city \u2014 shuttle or water taxi required (\u20ac\u20ac\u20ac)",
       "August heat + humidity + crowds is overwhelming",
-      "Venice is sinking and extremely fragile — overtourism is damaging it",
-      "Water taxis are shockingly expensive (€100+)",
+      "Venice is sinking and extremely fragile \u2014 overtourism is damaging it",
+      "Water taxis are shockingly expensive (\u20ac100+)",
       "No suitcases with wheels allowed on many bridges/streets"
     ],
     "packing_nudges": [
@@ -57322,7 +58233,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "35-67°F — mild Pacific Northwest",
+      "temp_range": "35-67\u00b0F \u2014 mild Pacific Northwest",
       "humidity": "Moderate to high; drier summers",
       "rain": "Wet Oct-Mar; very dry Jul-Aug",
       "wind": "Light; sheltered location",
@@ -57363,14 +58274,14 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "Butchart Gardens is consistently rated one of the world's best — a must-visit",
-      "Victoria has a very British character — afternoon tea at the Empress Hotel",
-      "The Inner Harbour is the heart of the city — beautiful and walkable",
+      "Butchart Gardens is consistently rated one of the world's best \u2014 a must-visit",
+      "Victoria has a very British character \u2014 afternoon tea at the Empress Hotel",
+      "The Inner Harbour is the heart of the city \u2014 beautiful and walkable",
       "Whale watching (orcas and humpbacks) is excellent May-Sep",
-      "Victoria is one of the mildest cities in Canada — rarely freezing"
+      "Victoria is one of the mildest cities in Canada \u2014 rarely freezing"
     ],
     "packing_nudges": [
-      "Layers — it's mild but can be cool even in summer",
+      "Layers \u2014 it's mild but can be cool even in summer",
       "Light rain jacket for transitional season",
       "Comfortable walking shoes",
       "Sunscreen for summer",
@@ -57478,7 +58389,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "41-76°F — Galician Rías Baixas",
+      "temp_range": "41-76\u00b0F \u2014 Galician R\u00edas Baixas",
       "humidity": "High (71-77%)",
       "rain": "Wet year-round; drier Jun-Aug",
       "wind": "Atlantic influence; generally breezy",
@@ -57514,9 +58425,9 @@
       "Jan"
     ],
     "catches_off_guard": [
-      "Cíes Islands (boat trip) have some of Spain's best beaches",
-      "Albariño wine from Rías Baixas is exceptional",
-      "Seafood is extraordinary — pulpo a feira (octopus) essential",
+      "C\u00edes Islands (boat trip) have some of Spain's best beaches",
+      "Albari\u00f1o wine from R\u00edas Baixas is exceptional",
+      "Seafood is extraordinary \u2014 pulpo a feira (octopus) essential",
       "Less touristy than Mediterranean Spain",
       "Rain is part of the experience here"
     ],
@@ -57629,7 +58540,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "42-82°F — sheltered bay near Nice",
+      "temp_range": "42-82\u00b0F \u2014 sheltered bay near Nice",
       "humidity": "Moderate (55-70%)",
       "rain": "Dry summers; wetter autumn",
       "wind": "Very sheltered harbor",
@@ -57664,10 +58575,10 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "Anchor port — tender to shore",
-      "Gateway to Nice, Monaco, and Èze",
+      "Anchor port \u2014 tender to shore",
+      "Gateway to Nice, Monaco, and \u00c8ze",
       "Cocteau Chapel in the old town is a hidden gem",
-      "Beach is pebbly, not sand — water shoes help",
+      "Beach is pebbly, not sand \u2014 water shoes help",
       "Old town is small but genuinely charming"
     ],
     "packing_nudges": [
@@ -57779,7 +58690,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "72-89°F year-round",
+      "temp_range": "72-89\u00b0F year-round",
       "humidity": "Moderate (68-76%)",
       "rain": "Brief showers; wetter Aug-Nov",
       "wind": "Trades; breezy hilltops",
@@ -57817,7 +58728,7 @@
     ],
     "catches_off_guard": [
       "The Baths granite boulders are signature attraction",
-      "Tender port — sea conditions matter",
+      "Tender port \u2014 sea conditions matter",
       "Very small, quiet island",
       "Top of the Baths trail has spectacular views",
       "Spring Bay less crowded alternative"
@@ -57825,12 +58736,12 @@
     "packing_nudges": [
       "Water shoes for The Baths",
       "Reef-safe sunscreen",
-      "Cash — limited card acceptance",
+      "Cash \u2014 limited card acceptance",
       "Camera for boulder formations"
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "Jun 1 – Nov 30 (Atlantic)",
+      "hurricane_season": "Jun 1 \u2013 Nov 30 (Atlantic)",
       "peak_risk_months": [
         "Aug",
         "Sep",
@@ -57937,9 +58848,9 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "46-74°F cool desert coast",
+      "temp_range": "46-74\u00b0F cool desert coast",
       "humidity": "Moderate; fog common",
-      "rain": "Virtually none — Namib Desert coast",
+      "rain": "Virtually none \u2014 Namib Desert coast",
       "wind": "Moderate onshore breezes; fog frequent mornings",
       "daylight": "10-13.5 hours (Southern Hemisphere)"
     },
@@ -57980,11 +58891,11 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "Morning fog is extremely common — it burns off by midday usually",
+      "Morning fog is extremely common \u2014 it burns off by midday usually",
       "Sandwich Harbour 4x4 excursion is a highlight but weather-dependent",
       "The Skeleton Coast is hauntingly beautiful but desolate",
       "Flamingo lagoon is right at the waterfront",
-      "Water is cold (Benguela Current) — swimming is uncomfortable"
+      "Water is cold (Benguela Current) \u2014 swimming is uncomfortable"
     ],
     "packing_nudges": [
       "Warm layers for morning fog",
@@ -58095,7 +59006,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "26-71°F — gateway to Berlin",
+      "temp_range": "26-71\u00b0F \u2014 gateway to Berlin",
       "humidity": "Moderate to high (69-87%)",
       "rain": "Year-round; slightly drier spring",
       "wind": "Baltic coast; can be breezy",
@@ -58133,8 +59044,8 @@
       "Feb"
     ],
     "catches_off_guard": [
-      "Berlin is 2.5 hours by train — full day needed",
-      "Warnemünde itself is a charming fishing village",
+      "Berlin is 2.5 hours by train \u2014 full day needed",
+      "Warnem\u00fcnde itself is a charming fishing village",
       "Lighthouse has great views from the top",
       "Beach promenade (Strandpromenade) is pleasant walk",
       "Rostock old town is 15 min by S-Bahn"
@@ -58248,7 +59159,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "36-66°F — mild southeast Ireland",
+      "temp_range": "36-66\u00b0F \u2014 mild southeast Ireland",
       "humidity": "High year-round",
       "rain": "Frequent; slightly drier Apr-Jun",
       "wind": "Moderate; more sheltered than west coast",
@@ -58284,7 +59195,7 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "Waterford is Ireland's oldest city — founded by Vikings in 914 AD",
+      "Waterford is Ireland's oldest city \u2014 founded by Vikings in 914 AD",
       "House of Waterford Crystal factory tour is the main attraction",
       "The Viking Triangle has three excellent museums",
       "The city is compact and walkable from the port",
@@ -58399,10 +59310,10 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "40-68°F cool and windy year-round",
+      "temp_range": "40-68\u00b0F cool and windy year-round",
       "humidity": "Moderate to high",
       "rain": "Distributed year-round; winter wetter",
-      "wind": "Extremely windy — 'Windy Wellington' is accurate",
+      "wind": "Extremely windy \u2014 'Windy Wellington' is accurate",
       "daylight": "9.5-15.5 hours (Southern Hemisphere)"
     },
     "best_months_for": {
@@ -58438,8 +59349,8 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "Wellington may be the windiest city in the world — hold onto your hat",
-      "Te Papa (national museum) is world-class and free — great for any weather",
+      "Wellington may be the windiest city in the world \u2014 hold onto your hat",
+      "Te Papa (national museum) is world-class and free \u2014 great for any weather",
       "The cable car ride offers city views but closes in extreme wind",
       "Craft beer scene rivals any city globally",
       "The Weta Workshop tour (Lord of the Rings) is indoors"
@@ -58553,9 +59464,9 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "19-61°F — Prince William Sound gateway",
+      "temp_range": "19-61\u00b0F \u2014 Prince William Sound gateway",
       "humidity": "High; maritime",
-      "rain": "Very wet — 180+ inches/year",
+      "rain": "Very wet \u2014 180+ inches/year",
       "wind": "Can be strong through the pass",
       "daylight": "6-18.5 hours (seasonal)"
     },
@@ -58604,6 +59515,158 @@
       "Waterproof boots",
       "Binoculars",
       "Warm hat and gloves"
+    ],
+    "hazards": {
+      "hurricane_zone": false
+    },
+    "cruise_seasons": {
+      "high": [
+        "Jun",
+        "Jul",
+        "Aug"
+      ],
+      "transitional": [
+        "May",
+        "Sep"
+      ],
+      "low": [
+        "Oct",
+        "Nov",
+        "Dec",
+        "Jan",
+        "Feb",
+        "Mar",
+        "Apr"
+      ]
+    }
+  },
+  "wrangell": {
+    "tier": 1,
+    "timezone": "America/Anchorage",
+    "_source": "High/low: Wrangell Airport NOAA 1991-2020 (Wikipedia climate table, session 2026-09-03). Rain_days and humidity: Ketchikan entry in this file (nearest SE Alaska station with those fields).",
+    "monthly_averages": {
+      "jan": {
+        "high_f": 36,
+        "low_f": 29,
+        "rain_days": 18,
+        "humidity": 78
+      },
+      "feb": {
+        "high_f": 38,
+        "low_f": 30,
+        "rain_days": 16,
+        "humidity": 76
+      },
+      "mar": {
+        "high_f": 42,
+        "low_f": 32,
+        "rain_days": 17,
+        "humidity": 74
+      },
+      "apr": {
+        "high_f": 50,
+        "low_f": 37,
+        "rain_days": 17,
+        "humidity": 74
+      },
+      "may": {
+        "high_f": 58,
+        "low_f": 44,
+        "rain_days": 16,
+        "humidity": 74
+      },
+      "jun": {
+        "high_f": 61,
+        "low_f": 49,
+        "rain_days": 15,
+        "humidity": 76
+      },
+      "jul": {
+        "high_f": 64,
+        "low_f": 52,
+        "rain_days": 14,
+        "humidity": 79
+      },
+      "aug": {
+        "high_f": 63,
+        "low_f": 52,
+        "rain_days": 15,
+        "humidity": 81
+      },
+      "sep": {
+        "high_f": 58,
+        "low_f": 48,
+        "rain_days": 19,
+        "humidity": 82
+      },
+      "oct": {
+        "high_f": 49,
+        "low_f": 41,
+        "rain_days": 22,
+        "humidity": 82
+      },
+      "nov": {
+        "high_f": 41,
+        "low_f": 34,
+        "rain_days": 20,
+        "humidity": 80
+      },
+      "dec": {
+        "high_f": 37,
+        "low_f": 30,
+        "rain_days": 20,
+        "humidity": 79
+      }
+    },
+    "at_a_glance": {
+      "temp_range": "29-64\u00b0F \u2014 SE rainforest, slightly drier than Ketchikan",
+      "humidity": "High",
+      "rain": "~91 in/year; October wettest",
+      "wind": "Moderate; island-sheltered",
+      "daylight": "7-17.5 hours (seasonal)"
+    },
+    "best_months_for": {
+      "petroglyph_beach": [
+        "May",
+        "Jun",
+        "Jul",
+        "Aug",
+        "Sep"
+      ],
+      "anan_creek_bears": [
+        "Jul",
+        "Aug",
+        "Sep"
+      ],
+      "city_walking": [
+        "Jun",
+        "Jul",
+        "Aug"
+      ],
+      "low_crowds": [
+        "May",
+        "Sep"
+      ]
+    },
+    "avoid_months": [
+      "Nov",
+      "Dec",
+      "Jan",
+      "Feb",
+      "Mar"
+    ],
+    "catches_off_guard": [
+      "Wrangell is quieter and smaller than Ketchikan, 80 miles northwest",
+      "Petroglyph Beach is a short trip from the dock \u2014 tide matters",
+      "Anan Creek bear viewing is a floatplane or boat day, permit-limited",
+      "October rain is the year's peak",
+      "This is still a working lumber and fishing town"
+    ],
+    "packing_nudges": [
+      "Waterproof jacket and boots",
+      "Layers",
+      "Warm hat",
+      "Tide table if you walk Petroglyph Beach"
     ],
     "hazards": {
       "hurricane_zone": false
@@ -58707,7 +59770,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "65-97°F — tropical monsoon",
+      "temp_range": "65-97\u00b0F \u2014 tropical monsoon",
       "humidity": "Low dry season; extreme monsoon",
       "rain": "Monsoon Jun-Oct torrential; dry Nov-Apr",
       "wind": "Monsoon winds Jun-Oct",
@@ -58745,11 +59808,11 @@
       "Sep"
     ],
     "catches_off_guard": [
-      "Shwedagon Pagoda is Myanmar's most sacred site — covered in real gold",
-      "Monsoon season (Jun-Oct) brings extraordinary rainfall — streets flood",
+      "Shwedagon Pagoda is Myanmar's most sacred site \u2014 covered in real gold",
+      "Monsoon season (Jun-Oct) brings extraordinary rainfall \u2014 streets flood",
       "The dry season (Nov-Apr) is dramatically more pleasant",
       "Yangon's colonial architecture is fascinating but crumbling",
-      "Barefoot required at all pagodas — carry a bag for shoes"
+      "Barefoot required at all pagodas \u2014 carry a bag for shoes"
     ],
     "packing_nudges": [
       "Light breathable clothing",
@@ -58860,7 +59923,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "34-85°F — northern Dalmatia",
+      "temp_range": "34-85\u00b0F \u2014 northern Dalmatia",
       "humidity": "Moderate (49-70%)",
       "rain": "Wetter than south coast; drier summers",
       "wind": "Bura can be fierce here",
@@ -58893,7 +59956,7 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "Sea Organ plays music from wave action — mesmerizing",
+      "Sea Organ plays music from wave action \u2014 mesmerizing",
       "Sun Salutation light installation at sunset",
       "Hitchcock allegedly said Zadar has world's most beautiful sunset",
       "Less crowded than Dubrovnik or Split",
@@ -59008,7 +60071,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "43-86°F — Shipwreck Beach island",
+      "temp_range": "43-86\u00b0F \u2014 Shipwreck Beach island",
       "humidity": "Moderate (44-74%)",
       "rain": "Dry Jun-Aug; wet winters",
       "wind": "Moderate; west coast exposed",
@@ -59043,13 +60106,13 @@
     "avoid_months": [],
     "catches_off_guard": [
       "Navagio (Shipwreck) Beach only accessible by boat",
-      "Loggerhead sea turtles nest on south beaches — protected",
+      "Loggerhead sea turtles nest on south beaches \u2014 protected",
       "Blue Caves on north tip best in morning light",
       "Zante town rebuilt after 1953 earthquake",
       "South coast party scene very different from quiet north"
     ],
     "packing_nudges": [
-      "Reef-safe sunscreen — turtle nesting areas",
+      "Reef-safe sunscreen \u2014 turtle nesting areas",
       "Camera for Navagio",
       "Water shoes",
       "Cash for boat trips"
@@ -59157,7 +60220,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "69-87°F year-round tropical",
+      "temp_range": "69-87\u00b0F year-round tropical",
       "humidity": "High year-round",
       "rain": "Long rains Mar-May; short rains Nov-Dec; dry Jun-Oct",
       "wind": "Monsoon shifts create seasonal variety",
@@ -59201,7 +60264,7 @@
     ],
     "catches_off_guard": [
       "Stone Town's narrow alleys are fascinating but easy to get lost in",
-      "Spice farm tours are unique to Zanzibar — highly recommended",
+      "Spice farm tours are unique to Zanzibar \u2014 highly recommended",
       "Seaweed farming is visible at low tide on east coast beaches",
       "Long rains (Mar-May) can be truly torrential",
       "The east coast has the best beaches but is windier"
@@ -59315,7 +60378,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "34-68°F — Belgian North Sea coast",
+      "temp_range": "34-68\u00b0F \u2014 Belgian North Sea coast",
       "humidity": "High year-round",
       "rain": "Distributed; slightly drier spring",
       "wind": "Can be strong; exposed coast",
@@ -59358,8 +60421,8 @@
     },
     "avoid_months": [],
     "catches_off_guard": [
-      "Zeebrugge is the gateway to Bruges — 15 min by shuttle/taxi",
-      "Bruges is one of Europe's best-preserved medieval cities — a UNESCO site",
+      "Zeebrugge is the gateway to Bruges \u2014 15 min by shuttle/taxi",
+      "Bruges is one of Europe's best-preserved medieval cities \u2014 a UNESCO site",
       "Belgian chocolate, beer, and waffles are the holy trinity",
       "Ghent (30 min) is equally beautiful and less touristy than Bruges",
       "Brussels (1.5 hours) is reachable but ambitious for a port day"
@@ -59473,7 +60536,7 @@
       }
     },
     "at_a_glance": {
-      "temp_range": "69-90°F year-round warm",
+      "temp_range": "69-90\u00b0F year-round warm",
       "humidity": "Low dry; high wet",
       "rain": "Dry Nov-May; wet Jun-Oct",
       "wind": "Light; protected bay",
@@ -59527,7 +60590,7 @@
     ],
     "hazards": {
       "hurricane_zone": true,
-      "hurricane_season": "May 15 – Nov 30 (East Pacific)",
+      "hurricane_season": "May 15 \u2013 Nov 30 (East Pacific)",
       "peak_risk_months": [
         "Aug",
         "Sep",


### PR DESCRIPTION
## Summary

HLS `itw-alaska-seasonal-json` / #2446: add the seven missing Alaska ports to `assets/data/ports/seasonal-guides.json`.

college-fjord, homer, kodiak, misty-fjords, petersburg, valdez, wrangell.

Highs/lows (and rain_days where the table had them) from NOAA 1991–2020 via Wikipedia climate tables, opened 2026-09-03. Humidity and some rain_days from the nearest existing registry station, named in each entry's `_source`. Misty Fjords uses Ketchikan monthly averages (no monument station). College Fjord uses Valdez temps + Whittier humidity (no fjord station).

Registry 381 → 387 port keys. `_meta.lastUpdated` 2026-09-03.

Soli Deo Gloria.
