### PR TITLE
GSC: pier question resolved in person + new accessibility section

### DIFF
--- a/REASONING-LOG.md
+++ b/REASONING-LOG.md
@@ -221,6 +221,39 @@ unresolved-pier hedge with this lived answer, and the accessibility page's chair
 
 ---
 
+## 2026-09-03 — GSC article: the pier hedge replaced with the lived answer (syl)
+
+**Asked.** Ken: "Gsc had a pier. It's a long walk if you're disabled." — the promised
+in-person resolution of the Great Stirrup Cay article's open pier question.
+
+**Weighed.** The article had printed the pier as an unresolved conflict in EIGHT places
+(ai-summary, meta/og/twitter descriptions, FAQ JSON-LD, dek, answer-first paragraph, the
+pier section heading and its "genuinely murky" bullet) plus a future-tense promise to
+report from the island Thursday. Fixing the body and leaving the metadata stale is the
+failure mode that makes a site untrustworthy in AI answers, so all of them were updated
+together — 15 surgical replacements, each asserted present before substitution so a
+silent miss would fail loudly rather than half-apply. The reconciliation is stated rather
+than the old reports being deleted: working-pier reports and tender-arrival guides were
+BOTH accurate at different moments of a moving project, which is a more useful thing for
+a reader than a quiet correction. Accessibility got its own h2 with a findable id because
+"can I get ashore with a chair" is the actual search, and it carries Ken's exact hedge
+("not fully accessible but better than other islands") rather than being upgraded into a
+recommendation.
+
+**Decided.** 15 claim/metadata updates + a new accessibility section; freshness stamps to
+09-03; sidecar records the visit as PRIMARY tier and lists what it did and did NOT
+resolve. Validator PASS.
+
+**Unsure / honest limits recorded on the page itself.** Water access stays UNVERIFIED —
+no lift was seen deployed all week, and the one wheelchair-using guest who reported
+satisfaction neither swims nor uses hot tubs, so his experience cannot answer it; the
+page says so instead of inferring. Waterpark and lagoon PRICING also stays unverified —
+the zipline board was the only price list photographed, so no dollar figure is printed for
+the waterpark. Departure time printed with its uncertainty ("in practice we left
+earlier"), since no printed time was captured.
+
+---
+
 ## 2026-09-03 — Reader-support CTA is now a publishing requirement, enforced (syl)
 
 **Asked.** Ken: "make sure the buymeacoffee link is required for an article to be

--- a/articles/great-stirrup-cay-changes-2026.factcheck.json
+++ b/articles/great-stirrup-cay-changes-2026.factcheck.json
@@ -1,10 +1,13 @@
 {
   "_doctrine": ".claude/skills/original-research/SKILL.md",
   "article_filename": "great-stirrup-cay-changes-2026.html",
-  "last_factcheck_date": "2026-08-22",
+  "last_factcheck_date": "2026-09-03",
   "verified_by": "Claude (patron syl, operator-supervised)",
   "hls_task": "article-great-stirrup-cay-is-about-to-change-pier-great",
-  "affiliate_posture": {"links_present": false, "rationale": "News/explainer; venue names are not commission links (stated on-page)."},
+  "affiliate_posture": {
+    "links_present": false,
+    "rationale": "News/explainer; venue names are not commission links (stated on-page)."
+  },
   "claims": {
     "waterpark_booklet_facts": {
       "claim": "Great Tides Waterpark: 19 slides, Tidal Tower, Wandering River, Cliffside Cove, Splash Cay, Grotto Bar; 'Starting this September, sailings to Great Stirrup Cay include access to book Great Tides Waterpark. Check the app for pricing' (quoted verbatim in-article); renderings/venue names subject to change",
@@ -75,5 +78,15 @@
     "confidence_15_20s": "PASS — included-vs-extra table gives a budgeting handle; September rule is unambiguous",
     "guided_20_30s": "PASS — per-date guidance (before Sept / after Sept / any date)",
     "score": "5/5 — ship"
+  },
+  "in_person_verification_2026_08_27": {
+    "visited_by": "Ken Baker (site author), aboard Norwegian Getaway, Great Stirrup Cay call 2026-08-27",
+    "source_tier": "PRIMARY — operator's own eyes on the island; supersedes the conflicting third-party reports this article previously printed as unresolved",
+    "pier_RESOLVED": "A pier was OPEN and in use; the ship docked and guests walked ashore rather than tendering. It is a TEMPORARY pier, in service while the permanent two-ship pier is still under construction. This closes the article's former open question and explains the contradiction: working-pier reports and tender-arrival guides were both accurate at different moments of an in-progress project.",
+    "accessibility_RESOLVED": "Long walk from ship to island facilities — operator's guidance is to bring the wheelchair/scooter. Verdict as dispatched: 'everything isn't fully accessible but it's better than other islands.' Printed with that exact hedge, not upgraded to a recommendation.",
+    "accessibility_NOT_resolved": "No pool or hot tub lift seen deployed anywhere on the sailing. One wheelchair-using guest reported satisfaction with his accommodations but does not swim or use hot tubs, so water access remains UNVERIFIED and is printed as such rather than inferred from his satisfaction.",
+    "zipline_signage": "Posted prices and safety rules photographed on site and quoted in the logbook Day 4: Osprey $99/$79, Seahawk $99/$79, Island Combo $139/$119, plus the sign's own '10% Bahamian sales tax added to the advertised prices' applying to tours AND rentals. Safety board quoted for the unassisted 20-foot ladder requirement and the not-recommended conditions.",
+    "schedule_note": "NCL's itinerary-change letter put the island call at 8 a.m.-8 p.m.; actual departure was earlier (operator recalls ~6, explicitly UNCONFIRMED — no printed time captured). Printed with that uncertainty attached, never as a firm time.",
+    "still_unverified": "Great Tides Waterpark and Great Life Lagoon PRICING. The zipline board was the only price list photographed; the booklet's upcharge markings remain the sole source for the waterpark, so no dollar figure is printed for it."
   }
 }

--- a/articles/great-stirrup-cay-changes-2026.html
+++ b/articles/great-stirrup-cay-changes-2026.html
@@ -20,8 +20,8 @@ All work on this project is offered as a gift to God.
   <script>document.documentElement.classList.remove('no-js');</script>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
   <meta name="referrer" content="strict-origin-when-cross-origin"/>
-  <meta name="ai-summary" content="NCL's Great Stirrup Cay is mid-transformation: the island's first pier opened December 28, 2025, closed April 1, 2026 for a two-ship expansion, and its reopening date is genuinely unclear — while the 19-slide Great Tides Waterpark opens for booked access starting September 2026, alongside the complimentary 28,000-square-foot Great Life Lagoon pool. What NCL's own booklet confirms, what's an upcharge, and what remains unverified. The author visits Thursday and will report."/>
-  <meta name="last-reviewed" content="2026-08-22"/>
+  <meta name="ai-summary" content="NCL's Great Stirrup Cay is mid-transformation: the island's first pier opened December 28, 2025, closed April 1, 2026 for a two-ship expansion, and its temporary replacement pier was OPEN and in use on August 27, 2026, verified in person — while the 19-slide Great Tides Waterpark opens for booked access starting September 2026, alongside the complimentary 28,000-square-foot Great Life Lagoon pool. What NCL's own booklet confirms, what's an upcharge, and what remains unverified. Updated from the author's own August 27, 2026 island visit: the pier is open, it is a long walk, and the island is imperfect but better than other private islands for a wheelchair user."/>
+  <meta name="last-reviewed" content="2026-09-03"/>
   <meta name="content-protocol" content="ICP-2"/>
   <meta name="robots" content="index,follow,max-image-preview:large"/>
   <meta name="color-scheme" content="light dark"/>
@@ -32,7 +32,7 @@ All work on this project is offered as a gift to God.
 
   <!-- SEO -->
   <title>Great Stirrup Cay Is About to Change: Pier, Waterpark, and What's True Right Now — In the Wake</title>
-  <meta name="description" content="NCL's private island is mid-transformation — a two-ship pier under construction, the Great Tides Waterpark opening for booking in September 2026, and a new free lagoon pool. What's confirmed, what costs extra, and what's still uncertain."/>
+  <meta name="description" content="NCL's private island is mid-transformation — a temporary pier now open while the two-ship pier is built, the Great Tides Waterpark opening for booking in September 2026, and a new free lagoon pool. What's confirmed, what costs extra, what's still uncertain — and a first-hand accessibility read from an August 2026 visit."/>
 
   <!-- Canonical -->
   <link rel="canonical" href="https://cruisinginthewake.com/articles/great-stirrup-cay-changes-2026.html"/>
@@ -41,7 +41,7 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="article"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:title" content="Great Stirrup Cay Is About to Change: Pier, Waterpark, and What's True Right Now"/>
-  <meta property="og:description" content="A two-ship pier under construction, a 19-slide waterpark opening in September, a new free lagoon pool — and one big open question about how you'll get ashore. Sorted into confirmed, upcharge, and unverified."/>
+  <meta property="og:description" content="A temporary pier open while the two-ship pier is built, a 19-slide waterpark opening in September, a new free lagoon pool — plus how the walk ashore actually reads with a wheelchair. Verified on the island August 27, 2026."/>
   <meta property="og:url" content="https://cruisinginthewake.com/articles/great-stirrup-cay-changes-2026.html"/>
   <meta property="og:image" content="https://cruisinginthewake.com/assets/social/articles-hero.jpg"/>
   <meta property="og:image:width" content="1200"/>
@@ -51,7 +51,7 @@ All work on this project is offered as a gift to God.
   <meta property="article:author" content="https://cruisinginthewake.com/authors/ken-baker.html"/>
   <meta name="twitter:card" content="summary_large_image"/>
   <meta name="twitter:title" content="Great Stirrup Cay Is About to Change"/>
-  <meta name="twitter:description" content="A two-ship pier under construction, a 19-slide waterpark opening in September, a new free lagoon pool — and one big open question about how you'll get ashore."/>
+  <meta name="twitter:description" content="A temporary pier open while the two-ship pier is built, a 19-slide waterpark opening in September, a new free lagoon pool — and an honest accessibility read from the island itself."/>
   <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/articles-hero.jpg"/>
 
   <!-- Structured data: Article -->
@@ -64,7 +64,7 @@ All work on this project is offered as a gift to God.
     "author":{"@type":"Person","name":"Ken Baker","url":"https://cruisinginthewake.com/authors/ken-baker.html"},
     "publisher":{"@type":"Organization","name":"In the Wake","logo":{"@type":"ImageObject","url":"https://cruisinginthewake.com/assets/logo_wake.png"}},
     "datePublished":"2026-08-22",
-    "dateModified":"2026-08-22",
+    "dateModified":"2026-09-03",
     "image":"https://cruisinginthewake.com/assets/social/articles-hero.jpg",
     "mainEntityOfPage":"https://cruisinginthewake.com/articles/great-stirrup-cay-changes-2026.html",
     "articleSection":"Cruise News",
@@ -82,7 +82,7 @@ All work on this project is offered as a gift to God.
     "@context":"https://schema.org",
     "@type":"FAQPage",
     "mainEntity":[
-      {"@type":"Question","name":"Does Great Stirrup Cay have a pier, or do ships tender?","acceptedAnswer":{"@type":"Answer","text":"Both answers have been true in 2026, which is why guests are confused. The island's first pier opened December 28, 2025, then closed April 1, 2026 so NCL could enlarge it into a two-ship pier. During the expansion, tendering has been the expected way ashore. Reports differ on whether the expanded pier has reopened, so verify with your ship — your cruise line app and your cabin's daily program will say whether your call is docked or tendered."}},
+      {"@type":"Question","name":"Does Great Stirrup Cay have a pier, or do ships tender?","acceptedAnswer":{"@type":"Answer","text":"Both answers have been true in 2026, which is why guests are confused. The island's first pier opened December 28, 2025, then closed April 1, 2026 so NCL could enlarge it into a two-ship pier. During the expansion, a temporary pier has carried guests ashore — confirmed open and in use on August 27, 2026, when this site's author docked there. It is a long walk from ship to island facilities. Conditions can still change while the permanent two-ship pier is finished, so confirm with your ship: your cruise line app and your cabin's daily program will say whether your call is docked or tendered."}},
       {"@type":"Question","name":"When does Great Tides Waterpark open?","acceptedAnswer":{"@type":"Answer","text":"Per NCL's own guest booklet, starting in September 2026 sailings to Great Stirrup Cay include access to book Great Tides Waterpark through the NCL app. It is booked access, not included in the fare, and NCL had not published pricing as of the booklet — the app is the source of truth. The park is described as 19 slides, the Tidal Tower, a Wandering River, and Cliffside Cove cliff jumping."}},
       {"@type":"Question","name":"What's free at Great Stirrup Cay and what costs extra?","acceptedAnswer":{"@type":"Answer","text":"The 28,000-square-foot Great Life Lagoon pool with swim-up bars carries no upcharge marker in NCL's booklet, and the beaches remain included. Marked as extra-charge in NCL's own materials: Great Tides Waterpark, Splash Cay, Cliffside Cove, the Flighthouse zipline, the Kayak Tour, Silver Cove Lagoon Villas, and the Silver Cove Spa."}},
       {"@type":"Question","name":"What else is new on the island?","acceptedAnswer":{"@type":"Answer","text":"NCL's island map marks several additions beyond the waterpark: a Welcome Plaza, a Panoramic Bridge, the Vibe Shore Club, Splash Harbor, and the Great Life Lagoon, alongside the pier itself. NCL's own materials caution that renderings and venue names are subject to change."}},
@@ -219,7 +219,7 @@ All work on this project is offered as a gift to God.
     <article class="card solo-article" itemscope itemtype="https://schema.org/Article">
       <header style="max-width:min(860px,92%);margin-inline:auto">
         <h1 itemprop="headline">Great Stirrup Cay Is About to Change: Pier, Waterpark, and What's True Right Now</h1>
-        <p class="dek" itemprop="description">NCL's private island is mid-transformation — a two-ship pier half-built, a 19-slide waterpark opening in September, a new free lagoon pool — and the guest-facing facts are scattered across marketing, news reports, and rumor. Here's the sorted version: confirmed, upcharge, and honestly unknown. I'm on the island Thursday, and I'll close the gaps in person.</p>
+        <p class="dek" itemprop="description">NCL's private island is mid-transformation — a two-ship pier half-built, a 19-slide waterpark opening in September, a new free lagoon pool — and the guest-facing facts are scattered across marketing, news reports, and rumor. Here's the sorted version: confirmed, upcharge, and honestly unknown — now updated from my own visit on August 27, 2026, which settled the pier question and answered the one readers with mobility needs actually ask.</p>
         <p class="byline">by <a href="/authors/ken-baker.html"><span itemprop="author">Ken Baker</span></a> | <time datetime="2026-08-22">August 22, 2026</time></p>
       </header>
 
@@ -227,27 +227,40 @@ All work on this project is offered as a gift to God.
 
       <!-- ICP-2 answer line -->
       <p class="answer-line" style="font-size:1.05rem;border-left:3px solid #0e6e8e;padding:0.75rem 1rem;background:#f8fbfc;border-radius:4px;margin:1rem 0 1.5rem">
-        <strong>Answer first:</strong> <a href="/ports/great-stirrup-cay.html">Great Stirrup Cay</a> got its first pier on December 28, 2025, then closed it on April 1, 2026 to rebuild it bigger — a two-ship pier — with tenders carrying guests ashore in the meantime, and its reopening date genuinely unclear as of this writing. Meanwhile, per NCL's own guest booklet, the 19-slide <strong>Great Tides Waterpark</strong> opens for bookable access on sailings starting September 2026 (an upcharge, priced only in the NCL app), while the 28,000-square-foot <strong>Great Life Lagoon</strong> pool carries no upcharge marker. If you're sailing there before September: you get beaches and whatever new spaces are finished — not the slides — and you should check your ship's app on the day to learn whether you dock or tender.</p>
+        <strong>Answer first:</strong> <a href="/ports/great-stirrup-cay.html">Great Stirrup Cay</a> got its first pier on December 28, 2025, then closed it on April 1, 2026 to rebuild it bigger — a two-ship pier. <strong>Updated from the island, August 27, 2026: a temporary pier was open and in use, and we walked ashore rather than tendered.</strong> It is a long walk; if you use a wheelchair or scooter, bring it. Meanwhile, per NCL's own guest booklet, the 19-slide <strong>Great Tides Waterpark</strong> opens for bookable access on sailings starting September 2026 (an upcharge, priced only in the NCL app), while the 28,000-square-foot <strong>Great Life Lagoon</strong> pool carries no upcharge marker. If you're sailing there before September: you get beaches and whatever new spaces are finished — not the slides — and you should check your ship's app on the day to learn whether you dock or tender.</p>
 
       <!-- Who this is for -->
       <section class="fit-guidance" aria-labelledby="who-this-is-for" style="background:#f8f9fa;border-left:3px solid #0e6e8e;padding:1rem 1.25rem;border-radius:4px;margin:1rem 0 1.5rem">
         <h2 id="who-this-is-for" style="margin-top:0;font-size:1.15rem">Who This Is For</h2>
         <p style="margin:0.5rem 0">Anyone with a Great Stirrup Cay call on an upcoming itinerary who keeps finding contradictory answers — "there's a pier now" versus "we tendered last week" — and anyone deciding whether the September waterpark opening should shape which sailing they book. This island is NCL's direct answer to Royal Caribbean's Perfect Day at CocoCay, and the next few months are when the comparison becomes real.</p>
-        <p style="margin:0.5rem 0">The reason this page can improve fast: I'm standing on the island <strong>Thursday</strong>, on the Getaway call that <a href="/articles/norwegian-getaway-nassau-repairs-overnight-2026.html">runs 8 a.m. to 8 p.m.</a> I'll see the pier state, the construction line, and what's actually open with my own eyes, and this article will be updated from that visit. Until then, every claim below names its source.</p>
+        <p style="margin:0.5rem 0">This page has now been updated from the island itself. I sailed the Getaway call on <strong>August 27, 2026</strong> — the call NCL's <a href="/articles/norwegian-getaway-nassau-repairs-overnight-2026.html">itinerary-change letter</a> had put at 8 a.m. to 8 p.m., though in practice we left earlier — and saw the pier state and what was open with my own eyes. The <a href="/articles/norwegian-getaway-aug-2026-logbook.html#day-4">day-by-day logbook</a> carries the raw account, including posted zipline pricing photographed on site. Every claim below still names its source, and the ones I verified in person now say so.</p>
       </section>
 
       <!-- THE PIER -->
-      <h2 id="pier">The Pier: One Honest Timeline, One Open Question</h2>
+      <h2 id="pier">The Pier: The Timeline, and the Question Now Answered</h2>
 
       <p>For most of its history, Great Stirrup Cay was a tender island — ships anchored off and ferried guests in by boat, which meant rough-weather days sometimes canceled the island entirely. The pier changes that math, which is why its timeline matters:</p>
 
       <ul style="line-height:1.7">
         <li><strong>December 28, 2025</strong> — the island's first pier opens and begins receiving ships, ending the tender-only era.</li>
         <li><strong>April 1, 2026</strong> — NCL closes that pier to enlarge it into a <strong>two-ship pier</strong>, so a pair of vessels can dock at once. During the work, tendering is again the way ashore.</li>
-        <li><strong>Now</strong> — the reopening date is the genuinely murky part. Some early-August reports said the expanded pier had reopened; other current guides still describe tendering as the expected arrival until the work completes. Those can't both be right, and I won't pretend to know which is.</li>
+        <li><strong>August 27, 2026 — verified in person.</strong> A pier was open and in use: our ship docked and we walked ashore. It is a <em>temporary</em> pier, in service while the permanent two-ship pier is still under construction. That resolves the contradiction that made this section unanswerable before — the early-August reports describing a working pier and the guides still describing tender arrivals were both describing real conditions at different moments in a project that is still moving.</li>
       </ul>
 
-      <p>So here is the honest guidance: <strong>assume nothing; check your ship.</strong> Whether your call docks or tenders will be in the cruise line app and the daily program aboard, and it can differ ship to ship while construction winds down. If you have mobility considerations, this is worth confirming before your cruise — tendering and docking are very different propositions with a wheelchair or scooter, and our <a href="/accessibility.html">accessibility guide</a> covers the tender question in more depth. Thursday, I'll report which one the Getaway actually did.</p>
+      <p>So here is the honest guidance: <strong>assume nothing; check your ship.</strong> Whether your call docks or tenders will be in the cruise line app and the daily program aboard, and it can differ ship to ship while construction winds down. Conditions can still change while the permanent pier is finished, so confirm with your own ship rather than with this page.</p>
+
+      <!-- ACCESSIBILITY -->
+      <h2 id="accessibility">Getting Ashore With a Wheelchair or Scooter: What I Saw</h2>
+
+      <p>This is the question I get asked about private islands more than any other, and marketing never answers it. So here is the first-hand version from August 27, 2026, with its limits stated.</p>
+
+      <p><strong>Bring the chair.</strong> The temporary pier means you walk ashore rather than transfer into a tender — which is the easier of the two propositions — but it is a <em>long</em> walk from the ship to the places you actually want to be. If you are standing in your cabin weighing whether the chair is worth the hassle, it is.</p>
+
+      <p><strong>The honest verdict: not fully accessible, but better than other islands.</strong> That is deliberately not a glowing review. Sand, distance, and a construction site in progress are all still sand, distance, and construction. But among tender-and-beach private islands, being able to roll off the ship instead of being lifted into a boat is a real difference, and "better than the others" is worth knowing when you are choosing between itineraries.</p>
+
+      <p><strong>What I could not verify.</strong> I did not see a pool or hot tub lift deployed anywhere on this sailing, island or ship. I spoke with one guest using a wheelchair who was satisfied with the accommodations he'd received — but he doesn't swim and doesn't use hot tubs, so his experience can't answer the water-access question either. It stays open here rather than getting a confident answer it hasn't earned. Our <a href="/accessibility.html">accessibility guide</a> and <a href="/disability-at-sea.html">disability at sea</a> pages carry the broader picture, and the <a href="/articles/jewel-of-the-seas-mobility-scooter-lawsuit-2026.html">Jewel of the Seas lawsuit</a> covers what happens when accommodation promises meet a real cruise.</p>
+
+      <p>One more accessibility-adjacent finding from the island, because it decides eligibility rather than comfort: the posted zipline safety board requires riders to be <em>"able to climb a 20-foot ladder unassisted"</em> and states the attraction is not recommended for anyone with balance problems, epilepsy, or heart, back, neck or shoulder conditions. That sentence appears in no brochure. Photographed and quoted in the <a href="/articles/norwegian-getaway-aug-2026-logbook.html#day-4">logbook</a>.</p>
 
       <!-- THE WATERPARK -->
       <h2 id="waterpark">Great Tides Waterpark: What NCL's Own Booklet Commits To</h2>
@@ -341,7 +354,7 @@ All work on this project is offered as a gift to God.
         <li><a href="/articles/cruise-embarkation-day-what-to-expect.html">Cruise Embarkation Day: What to Expect</a></li>
       </ul>
 
-      <p class="tiny muted" style="margin-top:1.5rem">Sources: NCL's "Great Tides Waterpark" guest booklet, May 2026 (waterpark contents, September booking access, upcharge markings, island map — full extracted text held in this site's records); pier timeline per cruise trade and guide reporting including <a href="https://www.cruisemapper.com/ports/great-stirrup-cay-port-1023" rel="nofollow noopener" target="_blank">CruiseMapper</a>, with the reopening date treated as unverified where reports conflict. Reviewed August 22, 2026. This page carries no affiliate links; the waterpark and island venues named are not commission links.</p>
+      <p class="tiny muted" style="margin-top:1.5rem">Sources: NCL's "Great Tides Waterpark" guest booklet, May 2026 (waterpark contents, September booking access, upcharge markings, island map — full extracted text held in this site's records); pier timeline per cruise trade and guide reporting including <a href="https://www.cruisemapper.com/ports/great-stirrup-cay-port-1023" rel="nofollow noopener" target="_blank">CruiseMapper</a>, with the reopening date, formerly treated as unverified where reports conflict, now resolved by the author's in-person visit on August 27, 2026 (temporary pier open and in use). Reviewed September 3, 2026. This page carries no affiliate links; the waterpark and island venues named are not commission links.</p>
 
       </div>
       <!-- READER SUPPORT — site-wide CTA -->


### PR DESCRIPTION
The Great Stirrup Cay article had printed the pier as an unresolved conflict in **eight** places (ai-summary, meta/og/twitter descriptions, FAQ JSON-LD, dek, answer-first paragraph, pier heading, and the "genuinely murky" bullet) plus a future-tense promise to report from the island. All 15 claim and metadata sites are updated together from the August 27 visit — fixing the body while leaving metadata stale is exactly what makes a page untrustworthy in AI answers.

**Resolved:** a temporary pier was open and in use; guests walked ashore rather than tendering; the permanent two-ship pier is still under construction. The article now *reconciles* the old conflict rather than quietly deleting it — working-pier reports and tender-arrival guides were both accurate at different moments of a moving project.

**New `#accessibility` section** answers the question marketing never does: bring the chair, it's a long walk, and the island is "not fully accessible but better than other islands" — the operator's exact hedge, not upgraded into a recommendation. Also surfaces the posted zipline board's unassisted-ladder requirement, which decides eligibility rather than comfort.

**Explicitly still unverified, stated on the page:** water access (no pool or hot tub lift seen deployed all week; the one wheelchair-using guest who reported satisfaction neither swims nor uses hot tubs, so his experience can't answer it), and Great Tides Waterpark pricing (the zipline board was the only price list photographed).

Freshness stamps to 2026-09-03; sidecar records the visit as primary-tier with what it did and did not resolve. Validator: PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ct4V1GGTFAHNfMVeFy5xJV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ct4V1GGTFAHNfMVeFy5xJV)_